### PR TITLE
Add FastAPI-based training web UI and automation hooks

### DIFF
--- a/webui/__init__.py
+++ b/webui/__init__.py
@@ -1,0 +1,1 @@
+"""WAN 2.2 training web UI package."""

--- a/webui/index.html
+++ b/webui/index.html
@@ -1,0 +1,603 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>WAN 2.2 LoRA Training</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #121212;
+        --panel: #1f1f1f;
+        --accent: #8ab4f8;
+        --accent-strong: #a66bff;
+        --border: #2a2a2a;
+        --text: #f1f3f4;
+        --muted: #9aa0a6;
+      }
+
+      body {
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        min-height: 100vh;
+      }
+
+      header {
+        padding: 2rem 1.5rem 1rem;
+        text-align: center;
+        background: linear-gradient(135deg, rgba(138, 180, 248, 0.25), rgba(166, 107, 255, 0.25));
+        border-bottom: 1px solid var(--border);
+      }
+
+      header h1 {
+        margin: 0 0 0.5rem;
+        font-size: 2rem;
+      }
+
+      header p {
+        margin: 0;
+        color: var(--muted);
+      }
+
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 1.5rem;
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      section {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 1.5rem;
+        box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+      }
+
+      h2 {
+        margin-top: 0;
+        font-size: 1.35rem;
+      }
+
+      #dropzone {
+        border: 2px dashed var(--accent);
+        border-radius: 16px;
+        padding: 2rem;
+        text-align: center;
+        transition: background 0.2s ease, border-color 0.2s ease;
+        cursor: pointer;
+        color: var(--muted);
+        font-size: 1rem;
+      }
+
+      #dropzone.active {
+        background: rgba(138, 180, 248, 0.12);
+        border-color: var(--accent-strong);
+        color: var(--text);
+      }
+
+      #upload-summary {
+        margin-top: 1rem;
+        font-size: 0.95rem;
+        color: var(--muted);
+      }
+
+      form {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .form-row {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .form-row.two-col {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+
+      label {
+        display: flex;
+        flex-direction: column;
+        font-weight: 600;
+        color: var(--muted);
+        gap: 0.4rem;
+      }
+
+      input[type="text"],
+      input[type="number"] {
+        padding: 0.6rem 0.75rem;
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        background: rgba(255, 255, 255, 0.04);
+        color: var(--text);
+        font-size: 0.95rem;
+      }
+
+      input[type="checkbox"] {
+        width: 1.1rem;
+        height: 1.1rem;
+        accent-color: var(--accent);
+      }
+
+      .toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        font-weight: 600;
+        color: var(--muted);
+      }
+
+      button {
+        border: none;
+        border-radius: 999px;
+        padding: 0.8rem 1.4rem;
+        font-size: 1rem;
+        font-weight: 600;
+        background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+        color: var(--text);
+        cursor: pointer;
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+
+      button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      button:not(:disabled):hover {
+        transform: translateY(-1px);
+      }
+
+      #status-line {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--accent);
+      }
+
+      #message {
+        color: var(--muted);
+        font-size: 0.95rem;
+        min-height: 1.2rem;
+      }
+
+      .metrics {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+
+      .metric-card {
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 1rem;
+        background: rgba(255, 255, 255, 0.03);
+      }
+
+      .metric-card h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1.1rem;
+      }
+
+      .metric-card p {
+        margin: 0.2rem 0;
+        font-size: 0.95rem;
+        color: var(--muted);
+      }
+
+      canvas {
+        width: 100% !important;
+        max-height: 320px;
+      }
+
+      #logOutput {
+        background: rgba(0, 0, 0, 0.35);
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        padding: 1rem;
+        max-height: 280px;
+        overflow-y: auto;
+        font-family: "JetBrains Mono", "Fira Code", monospace;
+        font-size: 0.85rem;
+        line-height: 1.45;
+        white-space: pre-wrap;
+      }
+
+      @media (max-width: 768px) {
+        header {
+          padding: 1.5rem 1rem 1rem;
+        }
+        main {
+          padding: 1rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>WAN 2.2 LoRA Training</h1>
+      <p>Upload your dataset, configure prompts, and launch training with live feedback.</p>
+    </header>
+    <main>
+      <section>
+        <h2>1. Upload dataset files</h2>
+        <div id="dropzone">
+          <strong>Drop images, videos, and caption files here</strong>
+          <div>or click to browse from your machine.</div>
+        </div>
+        <input id="fileInput" type="file" multiple hidden />
+        <div id="upload-summary">Files will be saved to /workspace/musubi-tuner/dataset/.</div>
+      </section>
+
+      <section>
+        <h2>2. Configure training</h2>
+        <div id="status-line">Status: <span id="status">Idle</span></div>
+        <div id="message"></div>
+        <form id="trainingForm">
+          <div class="form-row two-col">
+            <label>
+              Title suffix
+              <input type="text" name="titleSuffix" value="mylora" required />
+            </label>
+            <label>
+              Author
+              <input type="text" name="author" value="authorName" required />
+            </label>
+          </div>
+          <div class="form-row">
+            <label>
+              Dataset config path
+              <input type="text" name="datasetPath" value="/workspace/musubi-tuner/dataset/dataset.toml" required />
+            </label>
+          </div>
+          <div class="form-row two-col">
+            <label>
+              Save every N epochs
+              <input type="number" name="saveEvery" min="1" value="100" />
+            </label>
+            <label>
+              CPU threads per process (leave blank for auto)
+              <input type="number" name="cpuThreads" min="1" placeholder="Auto" />
+            </label>
+            <label>
+              Max data loader workers (leave blank for auto)
+              <input type="number" name="maxWorkers" min="1" placeholder="Auto" />
+            </label>
+          </div>
+          <div class="form-row two-col">
+            <label class="toggle">
+              <input type="checkbox" name="uploadCloud" checked />
+              Upload LoRAs to cloud storage after training
+            </label>
+            <label class="toggle">
+              <input type="checkbox" name="shutdownInstance" checked />
+              Shut down instance after training
+            </label>
+          </div>
+          <div class="form-row">
+            <button id="startButton" type="submit">Start training</button>
+          </div>
+        </form>
+      </section>
+
+      <section>
+        <h2>3. Live progress</h2>
+        <div class="metrics">
+          <div class="metric-card">
+            <h3>High noise</h3>
+            <p>Current step: <span id="highStep">-</span></p>
+            <p>Current loss: <span id="highLoss">-</span></p>
+          </div>
+          <div class="metric-card">
+            <h3>Low noise</h3>
+            <p>Current step: <span id="lowStep">-</span></p>
+            <p>Current loss: <span id="lowLoss">-</span></p>
+          </div>
+        </div>
+        <canvas id="lossChart"></canvas>
+      </section>
+
+      <section>
+        <h2>Training log</h2>
+        <pre id="logOutput">Waiting for training output…</pre>
+      </section>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-oXW5Hzkwmo7aX6ixkmKuuNHYsYAGdivgLPgAvFp8ZUBKbjsggq09uXBJgp7wa9u5" crossorigin="anonymous"></script>
+    <script>
+      const dropzone = document.getElementById('dropzone');
+      const fileInput = document.getElementById('fileInput');
+      const uploadSummary = document.getElementById('upload-summary');
+      const form = document.getElementById('trainingForm');
+      const statusEl = document.getElementById('status');
+      const messageEl = document.getElementById('message');
+      const startButton = document.getElementById('startButton');
+      const highStepEl = document.getElementById('highStep');
+      const highLossEl = document.getElementById('highLoss');
+      const lowStepEl = document.getElementById('lowStep');
+      const lowLossEl = document.getElementById('lowLoss');
+      const logOutput = document.getElementById('logOutput');
+
+      const MAX_LOG_LINES = 400;
+      const logLines = [];
+
+      let chart;
+      function initChart() {
+        const ctx = document.getElementById('lossChart').getContext('2d');
+        chart = new Chart(ctx, {
+          type: 'line',
+          data: {
+            datasets: [
+              {
+                label: 'High noise loss',
+                data: [],
+                borderColor: 'rgba(138, 180, 248, 0.95)',
+                backgroundColor: 'rgba(138, 180, 248, 0.15)',
+                tension: 0.2,
+                pointRadius: 0,
+                borderWidth: 2,
+              },
+              {
+                label: 'Low noise loss',
+                data: [],
+                borderColor: 'rgba(166, 107, 255, 0.95)',
+                backgroundColor: 'rgba(166, 107, 255, 0.15)',
+                tension: 0.2,
+                pointRadius: 0,
+                borderWidth: 2,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            animation: false,
+            maintainAspectRatio: false,
+            scales: {
+              x: {
+                type: 'linear',
+                title: { display: true, text: 'Step' },
+                ticks: { color: '#bdc1c6' },
+                grid: { color: 'rgba(189, 193, 198, 0.1)' },
+              },
+              y: {
+                title: { display: true, text: 'Loss' },
+                ticks: { color: '#bdc1c6' },
+                grid: { color: 'rgba(189, 193, 198, 0.1)' },
+              },
+            },
+            plugins: {
+              legend: {
+                labels: {
+                  color: '#e8eaed',
+                },
+              },
+            },
+          },
+        });
+      }
+
+      initChart();
+
+      function resetChart() {
+        chart.data.datasets.forEach((dataset) => {
+          dataset.data = [];
+        });
+        chart.update('none');
+        highStepEl.textContent = '-';
+        highLossEl.textContent = '-';
+        lowStepEl.textContent = '-';
+        lowLossEl.textContent = '-';
+        logLines.length = 0;
+        logOutput.textContent = 'Waiting for training output…';
+      }
+
+      async function uploadFiles(fileList) {
+        if (!fileList || !fileList.length) {
+          return;
+        }
+        const formData = new FormData();
+        Array.from(fileList).forEach((file) => formData.append('files', file, file.name));
+        uploadSummary.textContent = 'Uploading ' + fileList.length + ' file(s)…';
+        try {
+          const response = await fetch('/upload', {
+            method: 'POST',
+            body: formData,
+          });
+          if (!response.ok) {
+            const error = await response.json().catch(() => ({}));
+            throw new Error(error.detail || 'Upload failed');
+          }
+          const result = await response.json();
+          uploadSummary.textContent = `Uploaded ${result.count} file(s).`;
+        } catch (error) {
+          uploadSummary.textContent = error.message || 'Upload failed';
+        }
+      }
+
+      dropzone.addEventListener('click', () => fileInput.click());
+
+      dropzone.addEventListener('dragover', (event) => {
+        event.preventDefault();
+        dropzone.classList.add('active');
+      });
+
+      dropzone.addEventListener('dragleave', () => {
+        dropzone.classList.remove('active');
+      });
+
+      dropzone.addEventListener('drop', (event) => {
+        event.preventDefault();
+        dropzone.classList.remove('active');
+        if (event.dataTransfer?.files?.length) {
+          uploadFiles(event.dataTransfer.files);
+        }
+      });
+
+      fileInput.addEventListener('change', (event) => {
+        if (event.target.files?.length) {
+          uploadFiles(event.target.files);
+          fileInput.value = '';
+        }
+      });
+
+      function setStatus(text) {
+        statusEl.textContent = text;
+      }
+
+      function setMessage(text, isError = false) {
+        messageEl.textContent = text;
+        messageEl.style.color = isError ? '#ff8a80' : 'var(--muted)';
+      }
+
+      function updateLog(line) {
+        if (!line) {
+          return;
+        }
+        logLines.push(line);
+        if (logLines.length > MAX_LOG_LINES) {
+          logLines.splice(0, logLines.length - MAX_LOG_LINES);
+        }
+        logOutput.textContent = logLines.join('\n');
+        logOutput.scrollTop = logOutput.scrollHeight;
+      }
+
+      function applyHistory(datasetIndex, history) {
+        const dataset = chart.data.datasets[datasetIndex];
+        dataset.data = history
+          .map((point) => ({ x: Number(point.step), y: Number(point.loss) }))
+          .filter((point) => Number.isFinite(point.x) && Number.isFinite(point.y));
+      }
+
+      function updateMetric(run, point) {
+        const datasetIndex = run === 'high' ? 0 : 1;
+        const dataset = chart.data.datasets[datasetIndex];
+        if (!point) {
+          return;
+        }
+        const stepValue = Number(point.step);
+        const lossValue = Number(point.loss);
+        if (!Number.isFinite(stepValue) || !Number.isFinite(lossValue)) {
+          return;
+        }
+        if (dataset.data.length && dataset.data[dataset.data.length - 1].x === stepValue) {
+          dataset.data[dataset.data.length - 1].y = lossValue;
+        } else {
+          dataset.data.push({ x: stepValue, y: lossValue });
+        }
+        if (run === 'high') {
+          highStepEl.textContent = stepValue;
+          highLossEl.textContent = lossValue.toFixed(6);
+        } else {
+          lowStepEl.textContent = stepValue;
+          lowLossEl.textContent = lossValue.toFixed(6);
+        }
+        chart.update('none');
+      }
+
+      function applySnapshot(snapshot) {
+        setStatus(snapshot.status ? snapshot.status.charAt(0).toUpperCase() + snapshot.status.slice(1) : 'Idle');
+        startButton.disabled = !!snapshot.running;
+        applyHistory(0, snapshot.high?.history || []);
+        applyHistory(1, snapshot.low?.history || []);
+        const highCurrent = snapshot.high?.current;
+        const lowCurrent = snapshot.low?.current;
+        if (highCurrent) {
+          highStepEl.textContent = highCurrent.step;
+          highLossEl.textContent = Number(highCurrent.loss).toFixed(6);
+        }
+        if (lowCurrent) {
+          lowStepEl.textContent = lowCurrent.step;
+          lowLossEl.textContent = Number(lowCurrent.loss).toFixed(6);
+        }
+        chart.update('none');
+        logLines.length = 0;
+        (snapshot.logs || []).forEach((line) => logLines.push(line));
+        if (logLines.length) {
+          logOutput.textContent = logLines.join('\n');
+          logOutput.scrollTop = logOutput.scrollHeight;
+        } else {
+          logOutput.textContent = 'Waiting for training output…';
+        }
+      }
+
+      async function startTraining(event) {
+        event.preventDefault();
+        const formData = new FormData(form);
+        const payload = {
+          title_suffix: (formData.get('titleSuffix') || '').toString().trim() || 'mylora',
+          author: (formData.get('author') || '').toString().trim() || 'authorName',
+          dataset_path: (formData.get('datasetPath') || '').toString().trim(),
+          save_every: Number(formData.get('saveEvery')) || 100,
+          cpu_threads_per_process: formData.get('cpuThreads') ? Number(formData.get('cpuThreads')) : null,
+          max_data_loader_workers: formData.get('maxWorkers') ? Number(formData.get('maxWorkers')) : null,
+          upload_cloud: formData.get('uploadCloud') === 'on',
+          shutdown_instance: formData.get('shutdownInstance') === 'on',
+          auto_confirm: true,
+        };
+
+        if (!payload.dataset_path) {
+          setMessage('Dataset config path is required.', true);
+          return;
+        }
+
+        resetChart();
+        setMessage('Launching training…');
+        startButton.disabled = true;
+
+        try {
+          const response = await fetch('/train', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+          if (!response.ok) {
+            const error = await response.json().catch(() => ({}));
+            throw new Error(error.detail || 'Failed to start training');
+          }
+          setMessage('Training started. Watching logs…');
+        } catch (error) {
+          startButton.disabled = false;
+          setMessage(error.message || 'Failed to start training', true);
+        }
+      }
+
+      form.addEventListener('submit', startTraining);
+
+      function handleEvent(event) {
+        const data = event.data ? JSON.parse(event.data) : null;
+        if (!data) return;
+        switch (data.type) {
+          case 'snapshot':
+            applySnapshot(data);
+            break;
+          case 'status':
+            setStatus(data.status ? data.status.charAt(0).toUpperCase() + data.status.slice(1) : 'Idle');
+            startButton.disabled = !!data.running;
+            if (data.status === 'failed') {
+              setMessage('Training failed. See logs for details.', true);
+            } else if (data.status === 'completed') {
+              setMessage('Training completed successfully.');
+            }
+            break;
+          case 'metrics':
+            updateMetric(data.run, { step: data.step, loss: data.loss });
+            break;
+          case 'log':
+            updateLog(data.line);
+            break;
+          default:
+            break;
+        }
+      }
+
+      const eventSource = new EventSource('/events');
+      eventSource.onmessage = handleEvent;
+      eventSource.onerror = () => {
+        setMessage('Lost connection to live updates. Retrying…', true);
+      };
+    </script>
+  </body>
+</html>

--- a/webui/server.py
+++ b/webui/server.py
@@ -1,0 +1,363 @@
+import asyncio
+import json
+import os
+import re
+from collections import deque
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.responses import HTMLResponse, StreamingResponse
+from pydantic import BaseModel, Field
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_SCRIPT = REPO_ROOT / "run_wan_training.sh"
+INDEX_HTML_PATH = Path(__file__).with_name("index.html")
+DATASET_ROOT = Path("/workspace/musubi-tuner/dataset")
+LOG_DIR = Path("/workspace/musubi-tuner")
+HIGH_LOG = LOG_DIR / "run_high.log"
+LOW_LOG = LOG_DIR / "run_low.log"
+DATASET_ROOT.mkdir(parents=True, exist_ok=True)
+
+STEP_PATTERNS = [
+    re.compile(r"global_step(?:=|:)\s*(\d+)"),
+    re.compile(r"step(?:=|:)\s*(\d+)"),
+    re.compile(r"Iteration\s+(\d+)"),
+]
+LOSS_PATTERNS = [
+    re.compile(r"train_loss(?:=|:)\s*([0-9]+(?:\.[0-9]+)?(?:[eE][-+]?\d+)?)"),
+    re.compile(r"loss(?:=|:)\s*([0-9]+(?:\.[0-9]+)?(?:[eE][-+]?\d+)?)"),
+    re.compile(r"Loss\s*=?\s*([0-9]+(?:\.[0-9]+)?(?:[eE][-+]?\d+)?)"),
+]
+MAX_HISTORY_POINTS = 2000
+MAX_LOG_LINES = 400
+
+
+class TrainRequest(BaseModel):
+    title_suffix: str = Field(default="mylora", min_length=1)
+    author: str = Field(default="authorName", min_length=1)
+    dataset_path: str = Field(default=str(DATASET_ROOT / "dataset.toml"))
+    save_every: int = Field(default=100, ge=1)
+    cpu_threads_per_process: Optional[int] = Field(default=None, ge=1)
+    max_data_loader_workers: Optional[int] = Field(default=None, ge=1)
+    upload_cloud: bool = True
+    shutdown_instance: bool = True
+    auto_confirm: bool = True
+
+
+class EventManager:
+    def __init__(self) -> None:
+        self._listeners: List[asyncio.Queue] = []
+        self._lock = asyncio.Lock()
+
+    async def register(self) -> asyncio.Queue:
+        queue: asyncio.Queue = asyncio.Queue()
+        async with self._lock:
+            self._listeners.append(queue)
+        return queue
+
+    async def unregister(self, queue: asyncio.Queue) -> None:
+        async with self._lock:
+            if queue in self._listeners:
+                self._listeners.remove(queue)
+
+    async def publish(self, event: Dict) -> None:
+        async with self._lock:
+            listeners = list(self._listeners)
+        for queue in listeners:
+            await queue.put(event)
+
+
+class TrainingState:
+    def __init__(self) -> None:
+        self.process: Optional[asyncio.subprocess.Process] = None
+        self.status: str = "idle"
+        self.running: bool = False
+        self.history: Dict[str, List[Dict[str, float]]] = {"high": [], "low": []}
+        self.current: Dict[str, Optional[Dict[str, float]]] = {"high": None, "low": None}
+        self.pending: Dict[str, Dict[str, Optional[float]]] = {
+            "high": {"step": None, "loss": None},
+            "low": {"step": None, "loss": None},
+        }
+        self.logs: deque[str] = deque(maxlen=MAX_LOG_LINES)
+        self.stop_event: asyncio.Event = asyncio.Event()
+        self.tasks: List[asyncio.Task] = []
+
+    def reset_for_start(self) -> None:
+        self.history = {"high": [], "low": []}
+        self.current = {"high": None, "low": None}
+        self.pending = {
+            "high": {"step": None, "loss": None},
+            "low": {"step": None, "loss": None},
+        }
+        self.logs.clear()
+        self.stop_event = asyncio.Event()
+        self.tasks = []
+
+    def mark_started(self, process: asyncio.subprocess.Process) -> None:
+        self.reset_for_start()
+        self.process = process
+        self.status = "running"
+        self.running = True
+
+    def mark_finished(self, status: str) -> None:
+        self.status = status
+        self.running = False
+        self.process = None
+        if not self.stop_event.is_set():
+            self.stop_event.set()
+
+    def snapshot(self) -> Dict:
+        return {
+            "status": self.status,
+            "running": self.running,
+            "high": {
+                "history": list(self.history["high"]),
+                "current": self.current["high"],
+            },
+            "low": {
+                "history": list(self.history["low"]),
+                "current": self.current["low"],
+            },
+            "logs": list(self.logs),
+        }
+
+    def add_task(self, task: asyncio.Task) -> None:
+        self.tasks.append(task)
+
+    async def wait_for_tasks(self) -> None:
+        if not self.tasks:
+            return
+        done, pending = await asyncio.wait(self.tasks, timeout=0)
+        for task in pending:
+            task.cancel()
+
+    def append_log(self, line: str) -> None:
+        self.logs.append(line.rstrip())
+
+    async def update_metrics(self, run: str, step: Optional[int], loss: Optional[float]) -> Optional[Dict[str, float]]:
+        entry = self.pending[run]
+        if step is not None:
+            entry["step"] = int(step)
+        if loss is not None:
+            entry["loss"] = float(loss)
+        if entry["step"] is None or entry["loss"] is None:
+            return None
+        point = {"step": int(entry["step"]), "loss": float(entry["loss"])}
+        history = self.history[run]
+        if history and history[-1]["step"] == point["step"]:
+            history[-1] = point
+        else:
+            history.append(point)
+            if len(history) > MAX_HISTORY_POINTS:
+                del history[: len(history) - MAX_HISTORY_POINTS]
+        self.current[run] = point
+        entry["loss"] = None
+        return point
+
+
+event_manager = EventManager()
+training_state = TrainingState()
+app = FastAPI(title="WAN 2.2 Training UI")
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index() -> str:
+    if not INDEX_HTML_PATH.exists():
+        raise HTTPException(status_code=500, detail="UI assets missing")
+    return INDEX_HTML_PATH.read_text(encoding="utf-8")
+
+
+@app.post("/upload")
+async def upload(files: List[UploadFile] = File(...)) -> Dict:
+    if not files:
+        raise HTTPException(status_code=400, detail="No files provided")
+    saved = []
+    for file in files:
+        filename = Path(file.filename).name
+        if not filename:
+            continue
+        destination = DATASET_ROOT / filename
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with destination.open("wb") as output:
+            while True:
+                chunk = await file.read(1024 * 1024)
+                if not chunk:
+                    break
+                output.write(chunk)
+        await file.close()
+        saved.append(str(destination))
+    return {"saved": saved, "count": len(saved)}
+
+
+async def stream_process_output(process: asyncio.subprocess.Process) -> None:
+    if process.stdout is None:
+        return
+    try:
+        while True:
+            line = await process.stdout.readline()
+            if not line:
+                break
+            decoded = line.decode("utf-8", errors="ignore").rstrip()
+            if decoded:
+                training_state.append_log(decoded)
+                await event_manager.publish({"type": "log", "line": decoded})
+    finally:
+        if process.stdout:
+            process.stdout.close()
+
+
+def parse_metrics(line: str) -> Dict[str, Optional[float]]:
+    step_value: Optional[int] = None
+    loss_value: Optional[float] = None
+    for pattern in STEP_PATTERNS:
+        match = pattern.search(line)
+        if match:
+            try:
+                step_value = int(match.group(1))
+            except ValueError:
+                step_value = None
+            break
+    for pattern in LOSS_PATTERNS:
+        match = pattern.search(line)
+        if match:
+            try:
+                loss_value = float(match.group(1))
+            except ValueError:
+                loss_value = None
+            break
+    return {"step": step_value, "loss": loss_value}
+
+
+async def monitor_log_file(path: Path, run: str) -> None:
+    position = 0
+    while not training_state.stop_event.is_set():
+        if path.exists():
+            try:
+                with path.open("r", encoding="utf-8", errors="ignore") as handle:
+                    handle.seek(position)
+                    for line in handle:
+                        metrics = parse_metrics(line)
+                        if metrics["step"] is None and metrics["loss"] is None:
+                            continue
+                        point = await training_state.update_metrics(run, metrics["step"], metrics["loss"])
+                        if point:
+                            await event_manager.publish(
+                                {"type": "metrics", "run": run, "step": point["step"], "loss": point["loss"]}
+                            )
+                    position = handle.tell()
+            except OSError:
+                position = 0
+        await asyncio.sleep(1.0)
+    # Flush remaining data after stop
+    if path.exists():
+        try:
+            with path.open("r", encoding="utf-8", errors="ignore") as handle:
+                handle.seek(position)
+                for line in handle:
+                    metrics = parse_metrics(line)
+                    if metrics["step"] is None and metrics["loss"] is None:
+                        continue
+                    point = await training_state.update_metrics(run, metrics["step"], metrics["loss"])
+                    if point:
+                        await event_manager.publish(
+                            {"type": "metrics", "run": run, "step": point["step"], "loss": point["loss"]}
+                        )
+        except OSError:
+            pass
+
+
+async def wait_for_completion(process: asyncio.subprocess.Process) -> None:
+    returncode = await process.wait()
+    status = "completed" if returncode == 0 else "failed"
+    training_state.mark_finished(status)
+    summary = f"Training {status} (return code {returncode})"
+    training_state.append_log(summary)
+    await event_manager.publish({"type": "log", "line": summary})
+    await event_manager.publish({"type": "status", "status": status, "running": False, "returncode": returncode})
+
+
+def build_command(payload: TrainRequest) -> List[str]:
+    args = ["bash", str(RUN_SCRIPT)]
+    args.extend(["--title-suffix", payload.title_suffix])
+    args.extend(["--author", payload.author])
+    args.extend(["--dataset", payload.dataset_path])
+    args.extend(["--save-every", str(payload.save_every)])
+    if payload.cpu_threads_per_process is not None:
+        args.extend(["--cpu-threads-per-process", str(payload.cpu_threads_per_process)])
+    if payload.max_data_loader_workers is not None:
+        args.extend(["--max-data-loader-workers", str(payload.max_data_loader_workers)])
+    args.extend(["--upload-cloud", "Y" if payload.upload_cloud else "N"])
+    args.extend(["--shutdown-instance", "Y" if payload.shutdown_instance else "N"])
+    if payload.auto_confirm:
+        args.append("--auto-confirm")
+    return args
+
+
+@app.post("/train")
+async def start_training(payload: TrainRequest) -> Dict:
+    if not RUN_SCRIPT.exists():
+        raise HTTPException(status_code=500, detail="Training script not found")
+    if training_state.running:
+        raise HTTPException(status_code=409, detail="Training already in progress")
+
+    for log_path in (HIGH_LOG, LOW_LOG):
+        try:
+            log_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    command = build_command(payload)
+    env = os.environ.copy()
+    env.setdefault("PYTHONUNBUFFERED", "1")
+
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        cwd=str(REPO_ROOT),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        env=env,
+    )
+    training_state.mark_started(process)
+
+    await event_manager.publish({"type": "status", "status": "running", "running": True})
+
+    stdout_task = asyncio.create_task(stream_process_output(process))
+    high_task = asyncio.create_task(monitor_log_file(HIGH_LOG, "high"))
+    low_task = asyncio.create_task(monitor_log_file(LOW_LOG, "low"))
+    wait_task = asyncio.create_task(wait_for_completion(process))
+    training_state.add_task(stdout_task)
+    training_state.add_task(high_task)
+    training_state.add_task(low_task)
+    training_state.add_task(wait_task)
+
+    return {"status": "started"}
+
+
+@app.get("/status")
+async def status() -> Dict:
+    return training_state.snapshot()
+
+
+@app.get("/events")
+async def events() -> StreamingResponse:
+    queue = await event_manager.register()
+    snapshot = training_state.snapshot()
+
+    async def event_generator():
+        try:
+            yield f"data: {json.dumps({'type': 'snapshot', **snapshot})}\n\n"
+            while True:
+                event = await queue.get()
+                yield f"data: {json.dumps(event)}\n\n"
+        except asyncio.CancelledError:
+            pass
+        finally:
+            await event_manager.unregister(queue)
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    await training_state.wait_for_tasks()


### PR DESCRIPTION
## Summary
- add non-interactive CLI and environment overrides to `run_wan_training.sh`
- build a FastAPI web server and single-page UI for dataset uploads, training control, and live metrics
- provision web UI dependencies, supervisor service, and portal entry so the interface is available automatically

## Testing
- bash -n run_wan_training.sh
- python -m compileall webui

------
https://chatgpt.com/codex/tasks/task_e_69017520c4f48333b4ebced9f4b1cf3a