### PR TITLE
Add stop control and fix log monitoring

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -71,12 +71,30 @@
         cursor: pointer;
         color: var(--muted);
         font-size: 1rem;
+        outline: none;
       }
 
       #dropzone.active {
         background: rgba(138, 180, 248, 0.12);
         border-color: var(--accent-strong);
         color: var(--text);
+      }
+
+      #dropzone:focus-visible {
+        border-color: var(--accent-strong);
+        box-shadow: 0 0 0 3px rgba(138, 180, 248, 0.25);
+        color: var(--text);
+      }
+
+      #fileInput {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        border: 0;
+        clip: rect(0, 0, 0, 0);
+        overflow: hidden;
       }
 
       #upload-summary {
@@ -152,6 +170,10 @@
         transform: translateY(-1px);
       }
 
+      .button-secondary {
+        background: linear-gradient(135deg, #ff8a80, #ff5252);
+      }
+
       #status-line {
         font-size: 1rem;
         font-weight: 600;
@@ -224,11 +246,11 @@
     <main>
       <section>
         <h2>1. Upload dataset files</h2>
-        <div id="dropzone">
+        <div id="dropzone" role="button" tabindex="0" aria-controls="upload-summary" aria-describedby="dropzone-instructions">
           <strong>Drop images, videos, and caption files here</strong>
-          <div>or click to browse from your machine.</div>
+          <div id="dropzone-instructions">or click to browse from your machine.</div>
         </div>
-        <input id="fileInput" type="file" multiple hidden />
+        <input id="fileInput" type="file" multiple />
         <div id="upload-summary">Files will be saved to /workspace/musubi-tuner/dataset/.</div>
       </section>
 
@@ -277,8 +299,9 @@
               Shut down instance after training
             </label>
           </div>
-          <div class="form-row">
+          <div class="form-row two-col">
             <button id="startButton" type="submit">Start training</button>
+            <button id="stopButton" type="button" class="button-secondary" disabled>Stop training</button>
           </div>
         </form>
       </section>
@@ -306,7 +329,11 @@
       </section>
     </main>
 
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-oXW5Hzkwmo7aX6ixkmKuuNHYsYAGdivgLPgAvFp8ZUBKbjsggq09uXBJgp7wa9u5" crossorigin="anonymous"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
+      integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4"
+      crossorigin="anonymous"
+    ></script>
     <script>
       const dropzone = document.getElementById('dropzone');
       const fileInput = document.getElementById('fileInput');
@@ -319,6 +346,7 @@
       const highLossEl = document.getElementById('highLoss');
       const lowStepEl = document.getElementById('lowStep');
       const lowLossEl = document.getElementById('lowLoss');
+      const stopButton = document.getElementById('stopButton');
       const logOutput = document.getElementById('logOutput');
 
       const MAX_LOG_LINES = 400;
@@ -392,6 +420,7 @@
         lowLossEl.textContent = '-';
         logLines.length = 0;
         logOutput.textContent = 'Waiting for training output…';
+        stopButton.disabled = true;
       }
 
       async function uploadFiles(fileList) {
@@ -418,13 +447,38 @@
       }
 
       dropzone.addEventListener('click', () => fileInput.click());
-
-      dropzone.addEventListener('dragover', (event) => {
-        event.preventDefault();
-        dropzone.classList.add('active');
+      dropzone.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          fileInput.click();
+        }
       });
 
-      dropzone.addEventListener('dragleave', () => {
+      ['dragenter', 'dragover'].forEach((type) => {
+        dropzone.addEventListener(type, (event) => {
+          event.preventDefault();
+          event.dataTransfer.dropEffect = 'copy';
+          dropzone.classList.add('active');
+        });
+      });
+
+      dropzone.addEventListener('dragleave', (event) => {
+        if (!dropzone.contains(event.relatedTarget)) {
+          dropzone.classList.remove('active');
+        }
+      });
+
+      document.addEventListener('dragover', (event) => {
+        event.preventDefault();
+      });
+
+      document.addEventListener('drop', (event) => {
+        if (!dropzone.contains(event.target)) {
+          event.preventDefault();
+        }
+      });
+
+      dropzone.addEventListener('mouseleave', () => {
         dropzone.classList.remove('active');
       });
 
@@ -500,6 +554,7 @@
       function applySnapshot(snapshot) {
         setStatus(snapshot.status ? snapshot.status.charAt(0).toUpperCase() + snapshot.status.slice(1) : 'Idle');
         startButton.disabled = !!snapshot.running;
+        stopButton.disabled = !snapshot.running;
         applyHistory(0, snapshot.high?.history || []);
         applyHistory(1, snapshot.low?.history || []);
         const highCurrent = snapshot.high?.current;
@@ -558,6 +613,7 @@
             throw new Error(error.detail || 'Failed to start training');
           }
           setMessage('Training started. Watching logs…');
+          stopButton.disabled = false;
         } catch (error) {
           startButton.disabled = false;
           setMessage(error.message || 'Failed to start training', true);
@@ -565,6 +621,24 @@
       }
 
       form.addEventListener('submit', startTraining);
+
+      async function stopTraining() {
+        stopButton.disabled = true;
+        setMessage('Stopping training…');
+        try {
+          const response = await fetch('/stop', { method: 'POST' });
+          if (!response.ok) {
+            const error = await response.json().catch(() => ({}));
+            throw new Error(error.detail || 'Failed to stop training');
+          }
+          setMessage('Stop requested. Waiting for training to halt…');
+        } catch (error) {
+          setMessage(error.message || 'Failed to stop training', true);
+          stopButton.disabled = false;
+        }
+      }
+
+      stopButton.addEventListener('click', stopTraining);
 
       function handleEvent(event) {
         const data = event.data ? JSON.parse(event.data) : null;
@@ -576,10 +650,15 @@
           case 'status':
             setStatus(data.status ? data.status.charAt(0).toUpperCase() + data.status.slice(1) : 'Idle');
             startButton.disabled = !!data.running;
+            stopButton.disabled = !data.running;
             if (data.status === 'failed') {
               setMessage('Training failed. See logs for details.', true);
             } else if (data.status === 'completed') {
               setMessage('Training completed successfully.');
+            } else if (data.status === 'stopping') {
+              setMessage('Stop requested. Waiting for training to halt…');
+            } else if (data.status === 'stopped') {
+              setMessage('Training stopped by user.');
             }
             break;
           case 'metrics':


### PR DESCRIPTION
## Summary
- add a stop endpoint and UI control so training can be terminated from the dashboard
- improve log monitoring to parse WAN progress lines correctly and avoid stream reader errors
- reset dataset metrics state when runs restart and handle truncated logs safely

## Testing
- python -m compileall webui/server.py

------
https://chatgpt.com/codex/tasks/task_e_6902f360f4608333a1b3b7295c0a5e12