### PR TITLE
Improve tooltip interaction on loss chart

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -621,6 +621,11 @@
             responsive: true,
             animation: false,
             maintainAspectRatio: false,
+            interaction: {
+              mode: 'index',
+              intersect: false,
+              axis: 'x',
+            },
             scales: {
               x: {
                 type: 'linear',
@@ -638,6 +643,26 @@
               legend: {
                 labels: {
                   color: '#e8eaed',
+                },
+              },
+              tooltip: {
+                intersect: false,
+                callbacks: {
+                  title: (context) => {
+                    if (!context?.length) {
+                      return '';
+                    }
+                    const step = context[0].parsed?.x;
+                    return Number.isFinite(step) ? `Step ${step}` : '';
+                  },
+                  label: (context) => {
+                    const label = context.dataset?.label || '';
+                    const loss = context.parsed?.y;
+                    if (!Number.isFinite(loss)) {
+                      return label;
+                    }
+                    return `${label}: ${loss.toFixed(6)}`;
+                  },
                 },
               },
             },


### PR DESCRIPTION
## Summary
- configure the loss chart interaction to use index-based hovering so tooltips appear without needing to hover an exact point
- add tooltip callbacks that show the step number along with formatted high and low noise loss values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904d2e0024883338d6b021b5f1cbf7d