### PR TITLE
Integrate SillyCaption dataset manager with training web UI

### DIFF
--- a/SillyCaption/index.html
+++ b/SillyCaption/index.html
@@ -79,9 +79,15 @@
             <h1>Silly Caption</h1>
             <div class="subtitle">Serious Edition</div>
         </div>
-        <a href="https://obsxrver.github.io" target="_blank" rel="noreferrer noopener" class="profile-link">
-            <img src="static/pfp.png">
-        </a>
+        <div class="header-right">
+            <nav class="top-nav" aria-label="Main navigation">
+                <a href="/" class="nav-link">Training Dashboard</a>
+                <a href="/SillyCaption" class="nav-link nav-link--active" aria-current="page">SillyCaption</a>
+            </nav>
+            <a href="https://obsxrver.github.io" target="_blank" rel="noreferrer noopener" class="profile-link">
+                <img src="static/pfp.png" alt="obsxrver profile" />
+            </a>
+        </div>
     </header>
     <main>
         <section class="controls">
@@ -198,6 +204,43 @@
                 <button id="btnClearAllCaptions">Clear All Captions</button>
             </div>
             <div class="hint">Your API key is only used locally in this browser tab.</div>
+        </section>
+
+        <section class="dataset-integration">
+            <div class="dataset-status">
+                <div class="dataset-status-row">
+                    <span class="dataset-status-label">Current dataset</span>
+                    <span id="datasetSourceLabel" class="badge dataset-source-badge">No dataset loaded</span>
+                </div>
+                <div id="datasetStatusMessage" class="dataset-status-message" aria-live="polite"></div>
+            </div>
+            <div class="dataset-actions">
+                <div class="dataset-actions-group">
+                    <div class="dataset-actions-row">
+                        <button id="btnImportActive">Load Active Training Dataset</button>
+                        <button id="btnExportActive" disabled>Export to Active Dataset</button>
+                    </div>
+                    <div class="dataset-hint">Import the dataset currently used by training or push your captions back to it.</div>
+                </div>
+                <div class="dataset-actions-group">
+                    <div class="library-row">
+                        <label for="librarySelect">Library datasets</label>
+                        <div class="library-select-row">
+                            <select id="librarySelect" aria-label="Saved datasets"></select>
+                            <button id="btnLoadLibrary">Load</button>
+                            <button id="btnRefreshLibrary" class="secondary">Refresh</button>
+                        </div>
+                    </div>
+                    <div class="library-row">
+                        <label for="libraryNameInput">Save to library</label>
+                        <div class="library-save-row">
+                            <input type="text" id="libraryNameInput" placeholder="Dataset name" autocomplete="off">
+                            <button id="btnExportLibrary" disabled>Save</button>
+                        </div>
+                    </div>
+                    <div class="dataset-hint">Datasets are stored on this instance inside <code>SillyCaption/Datasets</code>.</div>
+                </div>
+            </div>
         </section>
 
         <section class="status">

--- a/SillyCaption/static/styles.css
+++ b/SillyCaption/static/styles.css
@@ -159,6 +159,43 @@ header .profile-link:hover {
   box-shadow: 0 0 20px rgba(249, 115, 22, 0.6), 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
+header .header-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.top-nav {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.nav-link {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 16px;
+  border-radius: 9999px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  border: 1px solid transparent;
+  transition: all 0.2s ease;
+}
+
+.nav-link:hover {
+  color: var(--text);
+  border-color: rgba(249, 115, 22, 0.35);
+  background: rgba(249, 115, 22, 0.18);
+}
+
+.nav-link--active {
+  color: #ffffff;
+  border-color: rgba(249, 115, 22, 0.45);
+  background: rgba(249, 115, 22, 0.28);
+}
+
 header .profile-link img {
   width: 100%;
   height: 100%;
@@ -244,6 +281,115 @@ main {
   transform: translateY(-2px);
   box-shadow: var(--shadow-xl);
   border-color: var(--border-light);
+}
+
+.dataset-integration {
+  margin-top: 24px;
+  background: rgba(26, 26, 26, 0.9);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 28px 32px;
+  box-shadow: var(--shadow-lg);
+  display: grid;
+  gap: 20px;
+}
+
+.dataset-status {
+  display: grid;
+  gap: 6px;
+}
+
+.dataset-status-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.dataset-status-label {
+  font-size: 0.9rem;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.dataset-source-badge {
+  background: rgba(138, 180, 248, 0.16);
+  border-color: rgba(138, 180, 248, 0.32);
+  color: #8ab4f8;
+}
+
+.dataset-source-badge.active {
+  background: rgba(249, 115, 22, 0.2);
+  border-color: rgba(249, 115, 22, 0.4);
+  color: #f6ad55;
+}
+
+.dataset-source-badge.library {
+  background: rgba(16, 185, 129, 0.18);
+  border-color: rgba(16, 185, 129, 0.35);
+  color: #34d399;
+}
+
+.dataset-source-badge.upload {
+  background: rgba(129, 199, 212, 0.18);
+  border-color: rgba(129, 199, 212, 0.35);
+  color: #80d8ff;
+}
+
+.dataset-status-message {
+  font-size: 0.9rem;
+  color: var(--muted);
+  min-height: 1.2em;
+}
+
+.dataset-status-message.error {
+  color: #ff8a80;
+}
+
+.dataset-actions {
+  display: grid;
+  gap: 24px;
+}
+
+.dataset-actions-group {
+  display: grid;
+  gap: 12px;
+}
+
+.dataset-actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.dataset-hint {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.library-row {
+  display: grid;
+  gap: 6px;
+}
+
+.library-select-row,
+.library-save-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.library-select-row select,
+.library-save-row input[type="text"] {
+  flex: 1 1 220px;
+  min-width: 200px;
+}
+
+.library-save-row button,
+.library-select-row button {
+  flex: 0 0 auto;
 }
 
 .field {
@@ -386,8 +532,26 @@ button#btnCancel {
   color: #ffffff; 
 }
 
-button#btnCancel:hover { 
-  background: var(--danger-hover); 
+button#btnCancel:hover {
+  background: var(--danger-hover);
+}
+
+button.secondary {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  box-shadow: none;
+}
+
+button.secondary:hover:not([disabled]) {
+  border-color: rgba(249, 115, 22, 0.35);
+  color: var(--text);
+}
+
+button.secondary[disabled] {
+  background: transparent;
+  color: var(--muted);
+  border-color: var(--border);
 }
 
 button#btnClear { 

--- a/webui/index.html
+++ b/webui/index.html
@@ -41,6 +41,42 @@
         color: var(--muted);
       }
 
+      .header-text {
+        max-width: 640px;
+        margin: 0 auto;
+      }
+
+      header .top-nav {
+        margin-top: 1.25rem;
+        display: flex;
+        justify-content: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .nav-link {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.6rem 1.2rem;
+        border-radius: 999px;
+        text-decoration: none;
+        font-weight: 600;
+        color: var(--text);
+        border: 1px solid transparent;
+        background: rgba(138, 180, 248, 0.15);
+        transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+      }
+
+      .nav-link:hover {
+        border-color: rgba(138, 180, 248, 0.4);
+        background: rgba(138, 180, 248, 0.25);
+      }
+
+      .nav-link--active {
+        border-color: rgba(166, 107, 255, 0.5);
+        background: rgba(166, 107, 255, 0.3);
+      }
+
       main {
         max-width: 1100px;
         margin: 0 auto;
@@ -359,8 +395,14 @@
   </head>
   <body>
     <header>
-      <h1>WAN 2.2 LoRA Training</h1>
-      <p>Upload your dataset, configure prompts, and launch training with live feedback.</p>
+      <div class="header-text">
+        <h1>WAN 2.2 LoRA Training</h1>
+        <p>Upload your dataset, configure prompts, and launch training with live feedback.</p>
+      </div>
+      <nav class="top-nav" aria-label="Main navigation">
+        <a href="/" class="nav-link nav-link--active" aria-current="page">Training UI</a>
+        <a href="/SillyCaption" class="nav-link">SillyCaption</a>
+      </nav>
     </header>
     <main>
       <section>

--- a/webui/server.py
+++ b/webui/server.py
@@ -6,16 +6,19 @@ import re
 import secrets
 import shutil
 import subprocess
+import tempfile
 from collections import deque
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi import FastAPI, File, HTTPException, Request, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
-from pydantic import BaseModel, Field
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field, ValidationError
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
 from starlette.responses import JSONResponse
+from typing import Literal
+from urllib.parse import quote
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RUN_SCRIPT = REPO_ROOT / "run_wan_training.sh"
@@ -24,10 +27,16 @@ DATASET_ROOT = Path("/workspace/musubi-tuner/dataset")
 LOG_DIR = Path("/workspace/musubi-tuner")
 HIGH_LOG = LOG_DIR / "run_high.log"
 LOW_LOG = LOG_DIR / "run_low.log"
+SILLYCAPTION_ROOT = REPO_ROOT / "SillyCaption"
+SILLYCAPTION_INDEX_PATH = SILLYCAPTION_ROOT / "index.html"
+SILLYCAPTION_STATIC_DIR = SILLYCAPTION_ROOT / "static"
+SILLYCAPTION_SRC_DIR = SILLYCAPTION_ROOT / "src"
+SILLYCAPTION_DATASETS_DIR = SILLYCAPTION_ROOT / "Datasets"
 API_KEY_CONFIG_PATH = Path.home() / ".config" / "vastai" / "vast_api_key"
 MANAGE_KEYS_URL = "https://cloud.vast.ai/manage-keys"
 CLOUD_SETTINGS_URL = "https://cloud.vast.ai/settings/"
 DATASET_ROOT.mkdir(parents=True, exist_ok=True)
+SILLYCAPTION_DATASETS_DIR.mkdir(parents=True, exist_ok=True)
 
 IMAGE_EXTENSIONS = {
     ".png",
@@ -37,6 +46,16 @@ IMAGE_EXTENSIONS = {
     ".bmp",
     ".gif",
 }
+VIDEO_EXTENSIONS = {
+    ".mp4",
+    ".mov",
+    ".avi",
+    ".mkv",
+    ".webm",
+    ".mpg",
+    ".mpeg",
+}
+MEDIA_EXTENSIONS = IMAGE_EXTENSIONS | VIDEO_EXTENSIONS
 CAPTION_PRIORITY = {".txt": 0, ".caption": 1, ".json": 2}
 CAPTION_EXTENSIONS = set(CAPTION_PRIORITY)
 CAPTION_PREVIEW_LIMIT = 500
@@ -271,6 +290,20 @@ class ApiKeyRequest(BaseModel):
     api_key: str = Field(min_length=1)
 
 
+class ExportItem(BaseModel):
+    name: str
+    relative_path: Optional[str] = None
+    caption: Optional[str] = None
+    source_type: Literal["upload", "active", "library"] = "upload"
+    library_name: Optional[str] = None
+    upload_field: Optional[str] = None
+
+
+class ExportPayload(BaseModel):
+    items: List[ExportItem]
+    dataset_name: Optional[str] = None
+
+
 class EventManager:
     def __init__(self) -> None:
         self._listeners: List[asyncio.Queue] = []
@@ -454,6 +487,19 @@ event_manager = EventManager()
 training_state = TrainingState()
 app = FastAPI(title="WAN 2.2 Training UI")
 
+if SILLYCAPTION_STATIC_DIR.exists():
+    app.mount(
+        "/SillyCaption/static",
+        StaticFiles(directory=str(SILLYCAPTION_STATIC_DIR)),
+        name="sillycaption-static",
+    )
+if SILLYCAPTION_SRC_DIR.exists():
+    app.mount(
+        "/SillyCaption/src",
+        StaticFiles(directory=str(SILLYCAPTION_SRC_DIR)),
+        name="sillycaption-src",
+    )
+
 app.add_middleware(TokenAuthMiddleware, token=AUTH_TOKEN)
 
 
@@ -462,6 +508,13 @@ async def index() -> str:
     if not INDEX_HTML_PATH.exists():
         raise HTTPException(status_code=500, detail="UI assets missing")
     return INDEX_HTML_PATH.read_text(encoding="utf-8")
+
+
+@app.get("/SillyCaption", response_class=HTMLResponse)
+async def sillycaption_index() -> str:
+    if not SILLYCAPTION_INDEX_PATH.exists():
+        raise HTTPException(status_code=500, detail="SillyCaption assets missing")
+    return SILLYCAPTION_INDEX_PATH.read_text(encoding="utf-8")
 
 
 def _clear_dataset_directory() -> None:
@@ -554,6 +607,296 @@ def _collect_dataset_items() -> List[Dict[str, Any]]:
 
     items.sort(key=lambda item: item["image_path"].lower())
     return items
+
+
+def _normalize_export_path(value: str) -> Path:
+    normalized = value.replace("\\", "/").strip().lstrip("/")
+    if not normalized:
+        raise HTTPException(status_code=400, detail="Invalid file name")
+    candidate = Path(normalized)
+    if candidate.is_absolute() or any(part == ".." for part in candidate.parts):
+        raise HTTPException(status_code=400, detail="Invalid file path")
+    return candidate
+
+
+def _resolve_library_dataset(dataset_name: str) -> Path:
+    sanitized = dataset_name.strip()
+    if not sanitized:
+        raise HTTPException(status_code=400, detail="Dataset name is required")
+    if sanitized in {".", ".."}:
+        raise HTTPException(status_code=400, detail="Invalid dataset name")
+    if any(sep in sanitized for sep in ("/", "\\")):
+        raise HTTPException(status_code=400, detail="Dataset name cannot contain path separators")
+    if len(sanitized) > 200:
+        raise HTTPException(status_code=400, detail="Dataset name is too long")
+    root_resolved = SILLYCAPTION_DATASETS_DIR.resolve()
+    dataset_path = (SILLYCAPTION_DATASETS_DIR / sanitized).resolve()
+    if dataset_path == root_resolved or root_resolved not in dataset_path.parents:
+        raise HTTPException(status_code=400, detail="Dataset path is invalid")
+    return dataset_path
+
+
+def _ensure_library_dataset(dataset_name: str) -> Path:
+    dataset_path = _resolve_library_dataset(dataset_name)
+    dataset_path.mkdir(parents=True, exist_ok=True)
+    return dataset_path
+
+
+def _resolve_library_file(dataset_name: str, relative_path: str) -> Path:
+    dataset_root = _resolve_library_dataset(dataset_name)
+    relative = _normalize_export_path(relative_path)
+    target_path = (dataset_root / relative).resolve()
+    if not target_path.exists() or not target_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found in dataset")
+    if dataset_root not in target_path.parents:
+        raise HTTPException(status_code=400, detail="Invalid dataset path")
+    return target_path
+
+
+async def _write_upload_to_path(upload: UploadFile, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("wb") as handle:
+        while True:
+            chunk = await upload.read(1024 * 1024)
+            if not chunk:
+                break
+            handle.write(chunk)
+
+
+def _collect_sillycaption_items(dataset_root: Path, route_prefix: str) -> List[Dict[str, Any]]:
+    if not dataset_root.exists() or not dataset_root.is_dir():
+        return []
+
+    resolved_root = dataset_root.resolve()
+    captions: Dict[tuple[str, str], Dict[str, Any]] = {}
+
+    for file_path in resolved_root.rglob("*"):
+        if not file_path.is_file():
+            continue
+        suffix = file_path.suffix.lower()
+        if suffix not in CAPTION_EXTENSIONS:
+            continue
+
+        relative = file_path.relative_to(resolved_root)
+        parent_key = relative.parent.as_posix()
+        stem_key = file_path.stem.lower()
+        priority = CAPTION_PRIORITY.get(suffix, 999)
+        existing = captions.get((parent_key, stem_key))
+        if existing and existing["priority"] <= priority:
+            continue
+
+        try:
+            text = file_path.read_text(encoding="utf-8", errors="replace").strip()
+        except OSError:
+            text = ""
+
+        captions[(parent_key, stem_key)] = {
+            "caption_path": relative.as_posix(),
+            "caption_text": text,
+            "priority": priority,
+        }
+
+    items: List[Dict[str, Any]] = []
+
+    for file_path in resolved_root.rglob("*"):
+        if not file_path.is_file():
+            continue
+        suffix = file_path.suffix.lower()
+        if suffix not in MEDIA_EXTENSIONS:
+            continue
+
+        relative = file_path.relative_to(resolved_root)
+        parent_key = relative.parent.as_posix()
+        stem_key = file_path.stem.lower()
+        caption_info = captions.get((parent_key, stem_key), {})
+        encoded = quote(relative.as_posix(), safe="/")
+        media_type, _ = mimetypes.guess_type(str(file_path))
+        items.append(
+            {
+                "relative_path": relative.as_posix(),
+                "kind": "video" if suffix in VIDEO_EXTENSIONS else "image",
+                "media_url": f"{route_prefix}/{encoded}",
+                "caption_text": caption_info.get("caption_text"),
+                "caption_path": caption_info.get("caption_path"),
+                "media_type": media_type or "application/octet-stream",
+            }
+        )
+
+    items.sort(key=lambda item: item["relative_path"].lower())
+    return items
+
+
+async def _export_dataset(
+    items: List[ExportItem],
+    uploads: Dict[str, UploadFile],
+    target_root: Path,
+) -> Dict[str, Any]:
+    target_root = target_root.resolve()
+    target_root.parent.mkdir(parents=True, exist_ok=True)
+    temp_dir_path = Path(tempfile.mkdtemp(prefix="sillycaption_", dir=str(target_root.parent)))
+    written = 0
+
+    try:
+        for item in items:
+            relative_value = (item.relative_path or "").strip()
+            fallback_name = Path(item.name).name
+            relative_name = relative_value or fallback_name
+            relative_path = _normalize_export_path(relative_name)
+            destination = temp_dir_path / relative_path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+
+            if item.source_type == "upload":
+                field = item.upload_field
+                if not field:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Missing upload field for {relative_path.as_posix()}",
+                    )
+                upload = uploads.get(field)
+                if upload is None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Upload '{field}' not found for {relative_path.as_posix()}",
+                    )
+                await _write_upload_to_path(upload, destination)
+            elif item.source_type == "active":
+                source_relative = (item.relative_path or relative_path.as_posix()).strip()
+                source_path = _resolve_dataset_file(source_relative)
+                shutil.copy2(source_path, destination)
+            elif item.source_type == "library":
+                if not item.library_name:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"library_name is required for {relative_path.as_posix()}",
+                    )
+                source_relative = (item.relative_path or relative_path.as_posix()).strip()
+                source_path = _resolve_library_file(item.library_name, source_relative)
+                shutil.copy2(source_path, destination)
+            else:
+                raise HTTPException(status_code=400, detail=f"Unsupported source type: {item.source_type}")
+
+            caption_text = (item.caption or "").strip()
+            caption_path = destination.with_suffix(".txt")
+            if caption_text:
+                caption_path.parent.mkdir(parents=True, exist_ok=True)
+                caption_path.write_text(caption_text, encoding="utf-8")
+            else:
+                try:
+                    caption_path.unlink()
+                except FileNotFoundError:
+                    pass
+            written += 1
+
+        if target_root.exists():
+            shutil.rmtree(target_root)
+        temp_dir_path.replace(target_root)
+        return {"written": written}
+    finally:
+        for upload in uploads.values():
+            try:
+                await upload.close()
+            except Exception:
+                pass
+        if temp_dir_path.exists():
+            shutil.rmtree(temp_dir_path, ignore_errors=True)
+
+
+@app.get("/SillyCaption/api/active/items")
+async def sillycaption_active_items() -> Dict[str, Any]:
+    items = _collect_sillycaption_items(DATASET_ROOT, "/SillyCaption/api/active/media")
+    return {"items": items, "total": len(items)}
+
+
+@app.get("/SillyCaption/api/active/media/{path:path}")
+async def sillycaption_active_media(path: str) -> StreamingResponse:
+    file_path = _resolve_dataset_file(path)
+    media_type, _ = mimetypes.guess_type(str(file_path))
+    return StreamingResponse(file_path.open("rb"), media_type=media_type or "application/octet-stream")
+
+
+@app.get("/SillyCaption/api/library")
+async def sillycaption_library_datasets() -> Dict[str, Any]:
+    datasets: List[Dict[str, Any]] = []
+    root = SILLYCAPTION_DATASETS_DIR.resolve()
+    if not root.exists():
+        return {"datasets": datasets}
+
+    for entry in sorted(root.iterdir(), key=lambda p: p.name.lower()):
+        if not entry.is_dir():
+            continue
+        count = 0
+        try:
+            for file_path in entry.rglob("*"):
+                if file_path.is_file() and file_path.suffix.lower() in MEDIA_EXTENSIONS:
+                    count += 1
+        except OSError:
+            count = 0
+        datasets.append({"name": entry.name, "media_count": count})
+    return {"datasets": datasets}
+
+
+@app.get("/SillyCaption/api/library/{dataset_name}/items")
+async def sillycaption_library_items(dataset_name: str) -> Dict[str, Any]:
+    dataset_root = _resolve_library_dataset(dataset_name)
+    if not dataset_root.exists() or not dataset_root.is_dir():
+        raise HTTPException(status_code=404, detail="Dataset not found")
+    prefix = f"/SillyCaption/api/library/{quote(dataset_name, safe='')}/media"
+    items = _collect_sillycaption_items(dataset_root, prefix)
+    return {"items": items, "total": len(items)}
+
+
+@app.get("/SillyCaption/api/library/{dataset_name}/media/{path:path}")
+async def sillycaption_library_media(dataset_name: str, path: str) -> StreamingResponse:
+    file_path = _resolve_library_file(dataset_name, path)
+    media_type, _ = mimetypes.guess_type(str(file_path))
+    return StreamingResponse(file_path.open("rb"), media_type=media_type or "application/octet-stream")
+
+
+async def _parse_export_payload(form_data) -> ExportPayload:
+    payload_raw = form_data.get("payload")
+    if not isinstance(payload_raw, str):
+        raise HTTPException(status_code=400, detail="Missing payload")
+    try:
+        payload_dict = json.loads(payload_raw)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail="Invalid payload JSON") from exc
+    try:
+        return ExportPayload.parse_obj(payload_dict)
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid payload: {exc}") from exc
+
+
+def _extract_uploads(form_data) -> Dict[str, UploadFile]:
+    uploads: Dict[str, UploadFile] = {}
+    for key, value in form_data.multi_items():
+        if isinstance(value, UploadFile):
+            uploads[key] = value
+    return uploads
+
+
+@app.post("/SillyCaption/api/export/active")
+async def sillycaption_export_active(request: Request) -> Dict[str, Any]:
+    form = await request.form()
+    payload = await _parse_export_payload(form)
+    uploads = _extract_uploads(form)
+    result = await _export_dataset(payload.items, uploads, DATASET_ROOT)
+    return {"message": "Active training dataset updated.", **result}
+
+
+@app.post("/SillyCaption/api/export/library")
+async def sillycaption_export_library(request: Request) -> Dict[str, Any]:
+    form = await request.form()
+    payload = await _parse_export_payload(form)
+    if not payload.dataset_name:
+        raise HTTPException(status_code=400, detail="dataset_name is required")
+    dataset_root = _ensure_library_dataset(payload.dataset_name)
+    uploads = _extract_uploads(form)
+    result = await _export_dataset(payload.items, uploads, dataset_root)
+    return {
+        "message": f"Dataset '{payload.dataset_name}' saved to library.",
+        "dataset_name": payload.dataset_name,
+        **result,
+    }
 
 
 @app.post("/upload")


### PR DESCRIPTION
## Summary
- mount the SillyCaption frontend inside the FastAPI app and add dataset/library management endpoints
- link the training dashboard and SillyCaption pages for easy navigation
- update SillyCaption UI and scripts to handle importing/exporting datasets and library management

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6904f7e77a4c8333868d4c32551c9e03