### PR TITLE
Fix SillyCaption asset paths

### DIFF
--- a/SillyCaption/index.html
+++ b/SillyCaption/index.html
@@ -30,11 +30,11 @@
     <link rel="canonical" href="https://obsxrver.pro/SillyCaption/">
 
     <!-- Favicon and icons -->
-    <link rel="icon" href="static/favicon2.ico">
-    <link rel="apple-touch-icon" href="static/pfp.png">
+    <link rel="icon" href="/SillyCaption/static/favicon2.ico">
+    <link rel="apple-touch-icon" href="/SillyCaption/static/pfp.png">
 
     <!-- Stylesheet -->
-    <link rel="stylesheet" href="static/styles.css">
+    <link rel="stylesheet" href="/SillyCaption/static/styles.css">
 
     <!-- Cache control -->
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
@@ -85,7 +85,7 @@
                 <a href="/SillyCaption" class="nav-link nav-link--active" aria-current="page">SillyCaption</a>
             </nav>
             <a href="https://obsxrver.github.io" target="_blank" rel="noreferrer noopener" class="profile-link">
-                <img src="static/pfp.png" alt="obsxrver profile" />
+                <img src="/SillyCaption/static/pfp.png" alt="obsxrver profile" />
             </a>
         </div>
     </header>
@@ -256,8 +256,8 @@
         <a href="https://github.com/obsxrver/wan22-lora-training/" target="_blank" rel="noreferrer noopener">Perfect WAN 2.2 LoRA Training Pipeline</a>
     </footer>
 
-    <script src="src/3rd-party/jszip.min.js"></script>
-    <script src="src/script.js"></script>
+    <script src="/SillyCaption/src/3rd-party/jszip.min.js"></script>
+    <script src="/SillyCaption/src/script.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- point SillyCaption HTML asset references at the FastAPI static mounts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904fdf98ec48333b31b0625c66f2ddf