### PR TITLE
Fix captioning for preloaded datasets

### DIFF
--- a/SillyCaption/src/script.js
+++ b/SillyCaption/src/script.js
@@ -1013,16 +1013,17 @@ EXAMPLES:
     }
 
     const inputFiles = Array.from(ui.files?.files || []);
+    const hasPreloadedItems = Array.isArray(state.currentItems) && state.currentItems.length > 0;
 
-    if (inputFiles.length === 0) {
+    if (inputFiles.length === 0 && !hasPreloadedItems) {
       alert('Please select at least one input image or video file.');
       return;
     }
-    if (!state.currentItems || state.currentItems.length === 0) {
+    if (!hasPreloadedItems && inputFiles.length > 0) {
       await refreshItemsFromFiles();
     }
 
-    const items = state.currentItems || [];
+    const items = Array.isArray(state.currentItems) ? state.currentItems : [];
     let itemsToProcess = items;
 
     if (onlyUncaptioned) {


### PR DESCRIPTION
## Summary
- allow captioning runs to proceed when items were loaded from the active dataset or library
- preserve the original file selection guard for manual uploads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905a6bcfda48333ba829d6d8fceece9