### PR TITLE
Improve mobile media playback and SillyCaption model loading

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -22,6 +22,7 @@
         background: var(--bg);
         color: var(--text);
         min-height: 100vh;
+        overflow-x: hidden;
       }
 
       header {
@@ -224,6 +225,8 @@
 
       .dataset-card video.dataset-card-media {
         object-fit: cover;
+        width: 100%;
+        height: 100%;
       }
 
       .dataset-card-body {
@@ -645,6 +648,8 @@
           mediaElement.loop = true;
           mediaElement.playsInline = true;
           mediaElement.setAttribute('playsinline', '');
+          mediaElement.setAttribute('webkit-playsinline', '');
+          mediaElement.setAttribute('muted', '');
           mediaElement.controls = true;
           mediaElement.setAttribute('controlslist', 'nodownload noremoteplayback');
           mediaElement.draggable = false;


### PR DESCRIPTION
## Summary
- add persistent auth cookies and ranged streaming so dataset videos play on mobile
- adjust web UI styling for mobile overflow and inline video playback attributes
- keep SillyCaption item names intact for active datasets and render model options immediately

## Testing
- python -m compileall webui/server.py

------
https://chatgpt.com/codex/tasks/task_e_6905f29a00988333823de26f1a0d3b68