### PR TITLE
Add dataset ZIP download option to SillyCaption

### DIFF
--- a/SillyCaption/index.html
+++ b/SillyCaption/index.html
@@ -192,8 +192,9 @@
                 </div>
             </details>
 
-            <div class="field" style="display:flex;align-items:center;gap:12px;">
+            <div class="field" style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
                 <button id="btnSaveZip" disabled>Save Captions as ZIP</button>
+                <button id="btnDownloadDatasetZip" disabled>Download Dataset ZIP</button>
             </div>
 
             <div class="buttons">


### PR DESCRIPTION
## Summary
- add a UI control to download the entire SillyCaption dataset as a ZIP archive
- implement client-side packaging that collects media and captions from uploads or remote datasets and prepares a ZIP
- keep dataset controls responsive while a download is prepared and reuse status messaging for progress

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_690600e602c08333b548e771fd0556a7