### PR TITLE
Add I2V training mode to web UI and provisioning

### DIFF
--- a/vast_provision.sh
+++ b/vast_provision.sh
@@ -117,6 +117,16 @@ fi
     split_files/diffusion_models/wan2.2_t2v_low_noise_14B_fp16.safetensors \
     --local-dir models/diffusion_models &
 
+  hf download \
+    Comfy-Org/Wan_2.2_ComfyUI_Repackaged \
+    split_files/diffusion_models/wan2.2_i2v_high_noise_14B_fp16.safetensors \
+    --local-dir models/diffusion_models &
+
+  hf download \
+    Comfy-Org/Wan_2.2_ComfyUI_Repackaged \
+    split_files/diffusion_models/wan2.2_i2v_low_noise_14B_fp16.safetensors \
+    --local-dir models/diffusion_models &
+
   wait
 ) & pids+=($!)
 

--- a/webui/index.html
+++ b/webui/index.html
@@ -350,6 +350,48 @@
         accent-color: var(--accent);
       }
 
+      input[type="radio"] {
+        width: 1rem;
+        height: 1rem;
+        accent-color: var(--accent);
+      }
+
+      .mode-fieldset {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 1rem 1.25rem;
+        background: rgba(255, 255, 255, 0.04);
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .mode-fieldset legend {
+        padding: 0 0.35rem;
+        font-weight: 700;
+        color: var(--text);
+      }
+
+      .mode-options {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+      }
+
+      .mode-option {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-weight: 600;
+        color: var(--muted);
+      }
+
+      .mode-hint {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--muted);
+      }
+
       .toggle {
         display: flex;
         align-items: center;
@@ -540,6 +582,22 @@
               Dataset config path
               <input type="text" name="datasetPath" value="/workspace/musubi-tuner/dataset/dataset.toml" required />
             </label>
+          </div>
+          <div class="form-row">
+            <fieldset class="mode-fieldset">
+              <legend>Training task</legend>
+              <div class="mode-options" role="radiogroup" aria-label="Training task">
+                <label class="mode-option">
+                  <input type="radio" name="trainingMode" value="t2v" checked />
+                  <span>Text to Video (T2V)</span>
+                </label>
+                <label class="mode-option">
+                  <input type="radio" name="trainingMode" value="i2v" />
+                  <span>Image to Video (I2V)</span>
+                </label>
+              </div>
+              <p class="mode-hint">Choose I2V to train with the image-to-video task and models.</p>
+            </fieldset>
           </div>
           <div class="form-row two-col">
             <label>
@@ -1276,6 +1334,8 @@
       async function startTraining(event) {
         event.preventDefault();
         const formData = new FormData(form);
+        const trainingModeRaw = (formData.get('trainingMode') || 't2v').toString().toLowerCase();
+        const trainingMode = trainingModeRaw === 'i2v' ? 'i2v' : 't2v';
         const payload = {
           title_suffix: (formData.get('titleSuffix') || '').toString().trim() || 'mylora',
           author: (formData.get('author') || '').toString().trim() || 'authorName',
@@ -1286,6 +1346,7 @@
           upload_cloud: formData.get('uploadCloud') === 'on',
           shutdown_instance: formData.get('shutdownInstance') === 'on',
           auto_confirm: true,
+          training_mode: trainingMode,
         };
 
         if (currentCloudStatus && !currentCloudStatus.can_upload) {

--- a/webui/server.py
+++ b/webui/server.py
@@ -287,6 +287,7 @@ class TrainRequest(BaseModel):
     upload_cloud: bool = True
     shutdown_instance: bool = True
     auto_confirm: bool = True
+    training_mode: Literal["t2v", "i2v"] = "t2v"
 
 
 class ApiKeyRequest(BaseModel):
@@ -1270,6 +1271,7 @@ def build_command(payload: TrainRequest) -> List[str]:
         args.extend(["--max-data-loader-workers", str(payload.max_data_loader_workers)])
     args.extend(["--upload-cloud", "Y" if payload.upload_cloud else "N"])
     args.extend(["--shutdown-instance", "Y" if payload.shutdown_instance else "N"])
+    args.extend(["--mode", payload.training_mode])
     if payload.auto_confirm:
         args.append("--auto-confirm")
     return args


### PR DESCRIPTION
## Summary
- download the Wan 2.2 I2V diffusion models during provisioning
- add an I2V training mode to the runner script and expose a --mode flag
- surface the new mode in the WebUI and pass it through the FastAPI server

## Testing
- bash -n vast_provision.sh
- bash -n run_wan_training.sh
- python -m compileall webui

------
https://chatgpt.com/codex/tasks/task_e_6909340f69f08333a08bb0b516719026