### PR TITLE
Add dataset video conversion option and improve training stop

### DIFF
--- a/vast_provision.sh
+++ b/vast_provision.sh
@@ -89,7 +89,7 @@ fi
   pip install fastapi "uvicorn[standard]" python-multipart
   pip install tomli
   pip uninstall xformers
-  pip install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
+  pip install torch torchvision
 ) & pids+=($!)
 
 # Task 2: Download all four models concurrently

--- a/vast_provision.sh
+++ b/vast_provision.sh
@@ -87,7 +87,9 @@ fi
   pip install six
   pip install matplotlib
   pip install fastapi "uvicorn[standard]" python-multipart
-  pip install torch torchvision
+  pip install tomli
+  pip uninstall xformers
+  pip install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
 ) & pids+=($!)
 
 # Task 2: Download all four models concurrently

--- a/webui/index.html
+++ b/webui/index.html
@@ -655,6 +655,12 @@
               Shut down instance after training
             </label>
           </div>
+          <div class="form-row">
+            <label class="toggle">
+              <input type="checkbox" name="convertVideos" />
+              Convert dataset videos to 16 FPS before training
+            </label>
+          </div>
           <div id="cloudStatusMessage" class="status-note" aria-live="polite"></div>
           <div class="form-row">
             <label>
@@ -1468,6 +1474,7 @@
           max_data_loader_workers: formData.get('maxWorkers') ? Number(formData.get('maxWorkers')) : null,
           upload_cloud: formData.get('uploadCloud') === 'on',
           shutdown_instance: formData.get('shutdownInstance') === 'on',
+          convert_videos_to_16fps: formData.get('convertVideos') === 'on',
           auto_confirm: true,
           training_mode: trainingMode,
           noise_mode: noiseMode,


### PR DESCRIPTION
## Summary
- add an optional 16 FPS conversion toggle in the training UI and convert dataset videos with ffmpeg before launching training
- ensure the training subprocess runs in its own session so the stop command can terminate the entire process tree
- update the stop endpoint to send SIGTERM/SIGKILL to the process group and log forced shutdowns

## Testing
- python -m compileall webui

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69161d99ba8c8333948032e207b5e014)