### PR TITLE
Add preset management and customizable training parameters

### DIFF
--- a/presets/u/AI_Characters.json
+++ b/presets/u/AI_Characters.json
@@ -1,0 +1,51 @@
+{
+  "name": "/u/AI_Characters",
+  "dataset_path": "/workspace/wan22-lora-training/presets/u/AI_Characters/dataset.toml",
+  "training_mode": "t2v",
+  "noise_mode": "both",
+  "convert_videos_to_16fps": false,
+  "train_params": {
+    "split_commands": true,
+    "shared": {
+      "task": "t2v-A14B",
+      "vae": "/workspace/musubi-tuner/models/vae/split_files/vae/wan_2.1_vae.safetensors",
+      "t5": "/workspace/musubi-tuner/models/text_encoders/models_t5_umt5-xxl-enc-bf16.pth",
+      "mixed_precision": "fp16",
+      "fp8_base": true,
+      "optimizer_type": "adamw",
+      "learning_rate": 0.0003,
+      "gradient_checkpointing": true,
+      "gradient_accumulation_steps": 1,
+      "max_data_loader_n_workers": 8,
+      "network_module": "networks.lora_wan",
+      "network_dim": 16,
+      "network_alpha": 16,
+      "timestep_sampling": "shift",
+      "discrete_flow_shift": 1,
+      "max_train_epochs": 100,
+      "save_every_n_epochs": 20,
+      "seed": 5,
+      "optimizer_args": "weight_decay=0.1",
+      "max_grad_norm": 0,
+      "lr_scheduler": "polynomial",
+      "lr_scheduler_power": 8,
+      "lr_scheduler_min_lr_ratio": 0.00005,
+      "output_dir": "/workspace/musubi-tuner/output",
+      "metadata_author": "authorName",
+      "preserve_distribution_shape": true,
+      "sdpa": true
+    },
+    "high": {
+      "dit": "/workspace/musubi-tuner/models/diffusion_models/split_files/diffusion_models/wan2.2_t2v_high_noise_14B_fp16.safetensors",
+      "min_timestep": 875,
+      "max_timestep": 1000
+    },
+    "low": {
+      "dit": "/workspace/musubi-tuner/models/diffusion_models/split_files/diffusion_models/wan2.2_t2v_low_noise_14B_fp16.safetensors",
+      "min_timestep": 0,
+      "max_timestep": 875
+    }
+  },
+  "title_suffix": "mylora",
+  "author": "authorName"
+}

--- a/presets/u/AI_Characters/dataset.toml
+++ b/presets/u/AI_Characters/dataset.toml
@@ -1,0 +1,22 @@
+# resolution, caption_extension, batch_size, num_repeats, enable_bucket, bucket_no_upscale should be set in either general or datasets
+# otherwise, the default values will be used for each item
+# general configurations
+[general]
+resolution = [960 , 960]
+caption_extension = ".txt"
+batch_size = 1
+enable_bucket = true
+bucket_no_upscale = true
+[[datasets]]
+image_directory = "/workspace/musubi-tuner/dataset"
+cache_directory = "/workspace/musubi-tuner/dataset/cache"
+num_repeats = 1 # optional, default is 1. Number of times to repeat the dataset. Useful to balance the multiple datasets with different sizes.
+# other datasets can be added here. each dataset can have different configurations
+
+[[datasets]]
+video_directory = "/workspace/musubi-tuner/dataset"
+cache_directory = "/workspace/musubi-tuner/dataset/videocache"
+frame_extraction = "full" #start from the beginning of the video
+max_frames = 81 #only take 5 seconds 
+resolution = [298,298] # 0.088 megapixels, slightly higher than most guides recommend
+#340x340 took too long, this takes half as long and gave spectacular result. If you still struggle to produce good outputs, make sure all your videos are 16fps, only use high quality source material, and make sure your captions are consistent. 

--- a/presets/u/ding-a-ling-berries (turbo).json
+++ b/presets/u/ding-a-ling-berries (turbo).json
@@ -1,0 +1,62 @@
+{
+  "name": "/u/ding-a-ling-berries (turbo)",
+  "dataset_path": "/workspace/wan22-lora-training/presets/u/ding-a-ling-berries (turbo)/dataset.toml",
+  "training_mode": "t2v",
+  "noise_mode": "both",
+  "convert_videos_to_16fps": false,
+  "train_params": {
+    "split_commands": true,
+    "shared": {
+      "task": "t2v-A14B",
+      "vae": "/workspace/musubi-tuner/models/vae/split_files/vae/wan_2.1_vae.safetensors",
+      "t5": "/workspace/musubi-tuner/models/text_encoders/models_t5_umt5-xxl-enc-bf16.pth",
+      "discrete_flow_shift": 3,
+      "fp8_base": true,
+      "fp8_scaled": true,
+      "fp8_t5": true,
+      "gradient_accumulation_steps": 2,
+      "gradient_checkpointing": true,
+      "img_in_txt_in_offloading": true,
+      "learning_rate": 0.0001,
+      "log_with": "tensorboard",
+      "logging_dir": "/workspace/musubi-tuner/logs",
+      "lr_scheduler": "cosine",
+      "lr_warmup_steps": 100,
+      "max_data_loader_n_workers": 8,
+      "max_timestep": 1000,
+      "max_train_epochs": 40,
+      "min_timestep": 0,
+      "mixed_precision": "fp16",
+      "network_alpha": 16,
+      "network_args": [
+        "verbose=True",
+        "exclude_patterns=[]"
+      ],
+      "network_dim": 16,
+      "network_module": "networks.lora_wan",
+      "offload_inactive_dit": true,
+      "optimizer_type": "AdamW8bit",
+      "output_dir": "/workspace/musubi-tuner/output",
+      "persistent_data_loader_workers": true,
+      "save_every_n_epochs": 1,
+      "seed": 42,
+      "timestep_boundary": 875,
+      "timestep_sampling": "logsnr",
+      "vae_cache_cpu": true,
+      "vae_dtype": "float16",
+      "sdpa": true
+    },
+    "high": {
+      "dit": "/workspace/musubi-tuner/models/diffusion_models/split_files/diffusion_models/wan2.2_t2v_high_noise_14B_fp16.safetensors",
+      "min_timestep": 875,
+      "max_timestep": 1000
+    },
+    "low": {
+      "dit": "/workspace/musubi-tuner/models/diffusion_models/split_files/diffusion_models/wan2.2_t2v_low_noise_14B_fp16.safetensors",
+      "min_timestep": 0,
+      "max_timestep": 875
+    }
+  },
+  "title_suffix": "mylora",
+  "author": "authorName"
+}

--- a/presets/u/ding-a-ling-berries (turbo)/dataset.toml
+++ b/presets/u/ding-a-ling-berries (turbo)/dataset.toml
@@ -1,0 +1,18 @@
+[general]
+caption_extension = ".txt"
+batch_size = 2
+enable_bucket = true
+bucket_no_upscale = false
+resolution = [256, 256]
+
+[[datasets]]
+image_directory = "/workspace/musubi-tuner/dataset"
+cache_directory = "/workspace/musubi-tuner/dataset/cache"
+num_repeats = 1
+
+[[datasets]]
+video_directory = "/workspace/musubi-tuner/dataset"
+video_cache_directory = "/workspace/musubi-tuner/dataset/videocache"
+num_repeats = 1
+frame_extraction = "full"
+max_frames = 25

--- a/run_wan_training.sh
+++ b/run_wan_training.sh
@@ -18,6 +18,7 @@ T2V_LOW_DIT="$MUSUBI_DIR/models/diffusion_models/split_files/diffusion_models/wa
 I2V_HIGH_DIT="$MUSUBI_DIR/models/diffusion_models/split_files/diffusion_models/wan2.2_i2v_high_noise_14B_fp16.safetensors"
 I2V_LOW_DIT="$MUSUBI_DIR/models/diffusion_models/split_files/diffusion_models/wan2.2_i2v_low_noise_14B_fp16.safetensors"
 DEFAULT_DATASET="$MUSUBI_DIR/dataset/dataset.toml"
+DEFAULT_OUTPUT_DIR="$MUSUBI_DIR/output"
 
 # CLI overrides (populated via command line flags or environment variables)
 TITLE_SUFFIX_INPUT="${WAN_TITLE_SUFFIX:-}"
@@ -31,6 +32,7 @@ CLI_SHUTDOWN_INSTANCE="${WAN_SHUTDOWN_INSTANCE:-}"
 TRAINING_MODE_INPUT="${WAN_TRAINING_MODE:-}"
 NOISE_MODE_INPUT="${WAN_NOISE_MODE:-}"
 AUTO_CONFIRM=0
+TRAIN_PARAMS_PATH=""
 
 CLOUD_PERMISSION_DENIED=0
 CLOUD_CONNECTION_MESSAGE=""
@@ -52,6 +54,7 @@ Optional arguments (all fall back to interactive prompts when omitted):
   --mode [t2v|i2v]                 Select the training task (text-to-video or image-to-video)
   --noise-mode [both|high|low]     Choose whether to train high noise, low noise, or both
   --auto-confirm                   Skip the final confirmation prompt
+  --train-params PATH              JSON file with training argument presets
   --help                           Show this message and exit
 
 Environment variable overrides:
@@ -121,6 +124,10 @@ while [[ $# -gt 0 ]]; do
     --auto-confirm)
       AUTO_CONFIRM=1
       shift 1
+      ;;
+    --train-params)
+      TRAIN_PARAMS_PATH="$2"
+      shift 2
       ;;
     --help)
       print_usage
@@ -221,6 +228,91 @@ determine_attention_flags() {
     echo "--sdpa --blocks_to_swap 1"
   else
     echo "--sdpa"
+  fi
+}
+
+build_custom_train_args() {
+  local noise="$1"
+  local output_name="$2"
+  local default_dit="$3"
+  local min_ts="$4"
+  local max_ts="$5"
+  local default_output_dir="$6"
+
+  if [[ -z "$TRAIN_PARAMS_PATH" ]]; then
+    return 0
+  fi
+
+  if [[ ! -f "$TRAIN_PARAMS_PATH" ]]; then
+    echo "Custom training params file not found: $TRAIN_PARAMS_PATH" >&2
+    exit 1
+  fi
+
+  mapfile -t CUSTOM_TRAIN_ARGS < <(python3 - "$TRAIN_PARAMS_PATH" "$noise" "$output_name" "$DATASET" "$AUTHOR" "$default_dit" "$VAE" "$T5" "$TRAIN_TASK" "$ATTN_FLAGS" "$min_ts" "$max_ts" "$default_output_dir" <<'PY'
+import json
+import shlex
+import sys
+from pathlib import Path
+
+path, noise, output_name, dataset, author, default_dit, vae, t5, task, attn_flags, min_ts, max_ts, output_dir = sys.argv[1:]
+
+with open(path, "r", encoding="utf-8") as handle:
+    data = json.load(handle)
+
+split_commands = bool(data.get("split_commands"))
+shared = data.get("shared")
+high = data.get("high")
+low = data.get("low")
+
+run_config = {}
+if isinstance(shared, dict):
+    run_config.update(shared)
+
+if split_commands:
+    selected = high if noise == "high" else low
+    if isinstance(selected, dict):
+        run_config.update(selected)
+
+defaults = {
+    "dataset_config": dataset,
+    "output_name": output_name,
+    "metadata_title": output_name,
+    "metadata_author": author,
+    "dit": default_dit,
+    "vae": vae,
+    "t5": t5,
+    "task": task,
+    "min_timestep": float(min_ts),
+    "max_timestep": float(max_ts),
+    "output_dir": output_dir,
+}
+
+for key, value in defaults.items():
+    run_config.setdefault(key, value)
+
+args: list[str] = []
+for key, value in run_config.items():
+    if value is None:
+        continue
+    if isinstance(value, bool):
+        if value:
+            args.append(f"--{key}")
+    elif isinstance(value, (list, tuple)):
+        args.append(f"--{key}")
+        args.extend(str(item) for item in value)
+    else:
+        args.extend([f"--{key}", str(value)])
+
+if attn_flags.strip():
+    args.extend(shlex.split(attn_flags))
+
+print("\n".join(args))
+PY
+  )
+
+  if (( ${#CUSTOM_TRAIN_ARGS[@]} == 0 )); then
+    echo "No custom training arguments produced; check $TRAIN_PARAMS_PATH" >&2
+    exit 1
   fi
 }
 
@@ -877,41 +969,50 @@ main() {
     echo "Waiting for a free GPU for HIGH noise training..."
     HIGH_GPU=$(wait_for_free_gpu)
     echo "Starting HIGH on GPU $HIGH_GPU (port $HIGH_PORT) -> run_high.log"
+    local -a HIGH_TRAIN_ARGS=()
+    if [[ -n "$TRAIN_PARAMS_PATH" ]]; then
+      build_custom_train_args "high" "$HIGH_TITLE" "$HIGH_DIT" 875 1000 "$DEFAULT_OUTPUT_DIR"
+      HIGH_TRAIN_ARGS=("${CUSTOM_TRAIN_ARGS[@]}")
+    else
+      HIGH_TRAIN_ARGS=(
+        --task "$TRAIN_TASK"
+        --dit "$HIGH_DIT"
+        --vae "$VAE"
+        --t5 "$T5"
+        --dataset_config "$DATASET"
+        $ATTN_FLAGS
+        --mixed_precision fp16
+        --fp8_base
+        --optimizer_type adamw
+        --learning_rate 3e-4
+        --gradient_checkpointing
+        --gradient_accumulation_steps 1
+        --max_data_loader_n_workers "$MAX_DATA_LOADER_WORKERS"
+        --network_module networks.lora_wan
+        --network_dim 16
+        --network_alpha 16
+        --timestep_sampling shift
+        --discrete_flow_shift 1.0
+        --max_train_epochs 100
+        --save_every_n_epochs "$SAVE_EVERY"
+        --seed 5
+        --optimizer_args weight_decay=0.1
+        --max_grad_norm 0
+        --lr_scheduler polynomial
+        --lr_scheduler_power 8
+        --lr_scheduler_min_lr_ratio=5e-5
+        --output_dir "$DEFAULT_OUTPUT_DIR"
+        --output_name "$HIGH_TITLE"
+        --metadata_title "$HIGH_TITLE"
+        --metadata_author "$AUTHOR"
+        --preserve_distribution_shape
+        --min_timestep 875
+        --max_timestep 1000
+      )
+    fi
     MASTER_ADDR=127.0.0.1 MASTER_PORT="$HIGH_PORT" CUDA_VISIBLE_DEVICES="$HIGH_GPU" \
     "$ACCELERATE" launch --num_cpu_threads_per_process "$CPU_THREADS_PER_PROCESS" --num_processes 1 --main_process_port "$HIGH_PORT" src/musubi_tuner/wan_train_network.py \
-      --task "$TRAIN_TASK" \
-      --dit "$HIGH_DIT" \
-      --vae "$VAE" \
-      --t5 "$T5" \
-      --dataset_config "$DATASET" \
-      $ATTN_FLAGS \
-      --mixed_precision fp16 \
-      --fp8_base \
-      --optimizer_type adamw \
-      --learning_rate 3e-4 \
-      --gradient_checkpointing \
-      --gradient_accumulation_steps 1 \
-      --max_data_loader_n_workers "$MAX_DATA_LOADER_WORKERS" \
-      --network_module networks.lora_wan \
-      --network_dim 16 \
-      --network_alpha 16 \
-      --timestep_sampling shift \
-      --discrete_flow_shift 1.0 \
-      --max_train_epochs 100 \
-      --save_every_n_epochs "$SAVE_EVERY" \
-      --seed 5 \
-      --optimizer_args weight_decay=0.1 \
-      --max_grad_norm 0 \
-      --lr_scheduler polynomial \
-      --lr_scheduler_power 8 \
-      --lr_scheduler_min_lr_ratio=5e-5 \
-      --output_dir "$MUSUBI_DIR/output" \
-      --output_name "$HIGH_TITLE" \
-      --metadata_title "$HIGH_TITLE" \
-      --metadata_author "$AUTHOR" \
-      --preserve_distribution_shape \
-      --min_timestep 875 \
-      --max_timestep 1000 \
+      "${HIGH_TRAIN_ARGS[@]}" \
       > "$PWD/run_high.log" 2>&1 &
     HIGH_PID=$!
     WAIT_PIDS+=("$HIGH_PID")
@@ -929,41 +1030,50 @@ main() {
       LOW_GPU=$(wait_for_free_gpu)
     fi
     echo "Starting LOW on GPU $LOW_GPU (port $LOW_PORT) -> run_low.log"
+    local -a LOW_TRAIN_ARGS=()
+    if [[ -n "$TRAIN_PARAMS_PATH" ]]; then
+      build_custom_train_args "low" "$LOW_TITLE" "$LOW_DIT" 0 875 "$DEFAULT_OUTPUT_DIR"
+      LOW_TRAIN_ARGS=("${CUSTOM_TRAIN_ARGS[@]}")
+    else
+      LOW_TRAIN_ARGS=(
+        --task "$TRAIN_TASK"
+        --dit "$LOW_DIT"
+        --vae "$VAE"
+        --t5 "$T5"
+        --dataset_config "$DATASET"
+        $ATTN_FLAGS
+        --mixed_precision fp16
+        --fp8_base
+        --optimizer_type adamw
+        --learning_rate 3e-4
+        --gradient_checkpointing
+        --gradient_accumulation_steps 1
+        --max_data_loader_n_workers "$MAX_DATA_LOADER_WORKERS"
+        --network_module networks.lora_wan
+        --network_dim 16
+        --network_alpha 16
+        --timestep_sampling shift
+        --discrete_flow_shift 1.0
+        --max_train_epochs 100
+        --save_every_n_epochs "$SAVE_EVERY"
+        --seed 5
+        --optimizer_args weight_decay=0.1
+        --max_grad_norm 0
+        --lr_scheduler polynomial
+        --lr_scheduler_power 8
+        --lr_scheduler_min_lr_ratio=5e-5
+        --output_dir "$DEFAULT_OUTPUT_DIR"
+        --output_name "$LOW_TITLE"
+        --metadata_title "$LOW_TITLE"
+        --metadata_author "$AUTHOR"
+        --preserve_distribution_shape
+        --min_timestep 0
+        --max_timestep 875
+      )
+    fi
     MASTER_ADDR=127.0.0.1 MASTER_PORT="$LOW_PORT" CUDA_VISIBLE_DEVICES="$LOW_GPU" \
     "$ACCELERATE" launch --num_cpu_threads_per_process "$CPU_THREADS_PER_PROCESS" --num_processes 1 --main_process_port "$LOW_PORT" src/musubi_tuner/wan_train_network.py \
-      --task "$TRAIN_TASK" \
-      --dit "$LOW_DIT" \
-      --vae "$VAE" \
-      --t5 "$T5" \
-      --dataset_config "$DATASET" \
-      $ATTN_FLAGS \
-      --mixed_precision fp16 \
-      --fp8_base \
-      --optimizer_type adamw \
-      --learning_rate 3e-4 \
-      --gradient_checkpointing \
-      --gradient_accumulation_steps 1 \
-      --max_data_loader_n_workers "$MAX_DATA_LOADER_WORKERS" \
-      --network_module networks.lora_wan \
-      --network_dim 16 \
-      --network_alpha 16 \
-      --timestep_sampling shift \
-      --discrete_flow_shift 1.0 \
-      --max_train_epochs 100 \
-      --save_every_n_epochs "$SAVE_EVERY" \
-      --seed 5 \
-      --optimizer_args weight_decay=0.1 \
-      --max_grad_norm 0 \
-      --lr_scheduler polynomial \
-      --lr_scheduler_power 8 \
-      --lr_scheduler_min_lr_ratio=5e-5 \
-      --output_dir "$MUSUBI_DIR/output" \
-      --output_name "$LOW_TITLE" \
-      --metadata_title "$LOW_TITLE" \
-      --metadata_author "$AUTHOR" \
-      --preserve_distribution_shape \
-      --min_timestep 0 \
-      --max_timestep 875 \
+      "${LOW_TRAIN_ARGS[@]}" \
       > "$PWD/run_low.log" 2>&1 &
     LOW_PID=$!
     WAIT_PIDS+=("$LOW_PID")

--- a/webui/index.html
+++ b/webui/index.html
@@ -192,6 +192,80 @@
         color: var(--muted);
       }
 
+      .preset-row {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+        align-items: center;
+        margin-top: 0.35rem;
+      }
+
+      .preset-row input,
+      .preset-row select {
+        flex: 1;
+        min-width: 220px;
+      }
+
+      .param-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin-bottom: 0.5rem;
+      }
+
+      .param-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 0.75rem;
+        margin: 0.5rem 0 1rem;
+      }
+
+      .param-card {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 0.85rem;
+        background: rgba(255, 255, 255, 0.03);
+      }
+
+      .param-card label {
+        font-weight: 600;
+        display: block;
+        margin-bottom: 0.25rem;
+      }
+
+      .param-card input,
+      .param-card textarea,
+      .param-card select {
+        width: 100%;
+        padding: 0.55rem;
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        background: var(--bg);
+        color: var(--text);
+      }
+
+      .param-card textarea {
+        min-height: 70px;
+        resize: vertical;
+      }
+
+      .param-card .checkbox-row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .param-section-title {
+        margin: 0.5rem 0 0.25rem;
+        font-size: 1rem;
+      }
+
+      .hidden {
+        display: none;
+      }
+
       #dataset-preview-message {
         margin-top: 0.75rem;
         font-size: 0.9rem;
@@ -623,6 +697,25 @@
             </label>
           </div>
           <div class="form-row">
+            <label>
+              Presets
+              <div class="preset-row">
+                <select id="presetSelect" aria-label="Preset selector"></select>
+                <button type="button" id="loadPresetButton" class="button-secondary">Load preset</button>
+              </div>
+              <div class="preset-row">
+                <input
+                  type="text"
+                  id="presetNameInput"
+                  placeholder="Preset name, e.g. /u/AI_Characters"
+                  autocomplete="off"
+                />
+                <button type="button" id="savePresetButton">Save current as preset</button>
+              </div>
+              <div id="presetMessage" class="status-note" aria-live="polite"></div>
+            </label>
+          </div>
+          <div class="form-row">
             <fieldset class="mode-fieldset">
               <legend>Task</legend>
               <div class="mode-options" role="radiogroup" aria-label="Training task">
@@ -686,6 +779,25 @@
               <input type="checkbox" name="convertVideos" />
               Convert dataset videos to 16 FPS before training
             </label>
+          </div>
+          <div class="form-row">
+            <div class="param-header">
+              <h3 class="param-section-title">Training parameters</h3>
+              <label class="toggle inline">
+                <input type="checkbox" id="splitParamsToggle" />
+                Use different commands for high noise
+              </label>
+            </div>
+            <div>
+              <h4 class="param-section-title">Shared parameters</h4>
+              <div id="sharedParams" class="param-grid"></div>
+            </div>
+            <div id="perNoiseParams" class="hidden">
+              <h4 class="param-section-title">High noise overrides</h4>
+              <div id="highParams" class="param-grid"></div>
+              <h4 class="param-section-title">Low noise overrides</h4>
+              <div id="lowParams" class="param-grid"></div>
+            </div>
           </div>
           <div id="cloudStatusMessage" class="status-note" aria-live="polite"></div>
           <div class="form-row">
@@ -752,6 +864,16 @@
       const uploadSummary = document.getElementById('upload-summary');
       const datasetGrid = document.getElementById('dataset-grid');
       const datasetMessage = document.getElementById('dataset-preview-message');
+      const presetSelect = document.getElementById('presetSelect');
+      const loadPresetButton = document.getElementById('loadPresetButton');
+      const savePresetButton = document.getElementById('savePresetButton');
+      const presetNameInput = document.getElementById('presetNameInput');
+      const presetMessage = document.getElementById('presetMessage');
+      const sharedParamsContainer = document.getElementById('sharedParams');
+      const highParamsContainer = document.getElementById('highParams');
+      const lowParamsContainer = document.getElementById('lowParams');
+      const splitParamsToggle = document.getElementById('splitParamsToggle');
+      const perNoiseParams = document.getElementById('perNoiseParams');
       const form = document.getElementById('trainingForm');
       const statusEl = document.getElementById('status');
       const messageEl = document.getElementById('message');
@@ -786,6 +908,249 @@
       const MAX_LOG_LINES = 400;
       const logLines = [];
       const VIDEO_EXTENSION_PATTERN = /\.(mp4|mov|avi|mkv|webm|mpg|mpeg)$/i;
+      const DEFAULT_PATHS = {
+        vae: '/workspace/musubi-tuner/models/vae/split_files/vae/wan_2.1_vae.safetensors',
+        t5: '/workspace/musubi-tuner/models/text_encoders/models_t5_umt5-xxl-enc-bf16.pth',
+        t2vHigh: '/workspace/musubi-tuner/models/diffusion_models/split_files/diffusion_models/wan2.2_t2v_high_noise_14B_fp16.safetensors',
+        t2vLow: '/workspace/musubi-tuner/models/diffusion_models/split_files/diffusion_models/wan2.2_t2v_low_noise_14B_fp16.safetensors',
+        i2vHigh: '/workspace/musubi-tuner/models/diffusion_models/split_files/diffusion_models/wan2.2_i2v_high_noise_14B_fp16.safetensors',
+        i2vLow: '/workspace/musubi-tuner/models/diffusion_models/split_files/diffusion_models/wan2.2_i2v_low_noise_14B_fp16.safetensors',
+        outputDir: '/workspace/musubi-tuner/output',
+      };
+
+      const PARAM_DEFINITIONS = [
+        { key: 'task', label: 'Task', type: 'text' },
+        { key: 'dit', label: 'DiT path', type: 'text' },
+        { key: 'dit_high_noise', label: 'High noise DiT', type: 'text' },
+        { key: 'vae', label: 'VAE path', type: 'text' },
+        { key: 't5', label: 'T5 path', type: 'text' },
+        { key: 'mixed_precision', label: 'Mixed precision', type: 'text' },
+        { key: 'fp8_base', label: 'FP8 base', type: 'checkbox' },
+        { key: 'fp8_scaled', label: 'FP8 scaled', type: 'checkbox' },
+        { key: 'fp8_t5', label: 'FP8 T5', type: 'checkbox' },
+        { key: 'optimizer_type', label: 'Optimizer type', type: 'text' },
+        { key: 'learning_rate', label: 'Learning rate', type: 'number' },
+        { key: 'gradient_checkpointing', label: 'Gradient checkpointing', type: 'checkbox' },
+        { key: 'gradient_accumulation_steps', label: 'Gradient accumulation steps', type: 'number' },
+        { key: 'max_data_loader_n_workers', label: 'Max data loader workers', type: 'number' },
+        { key: 'network_module', label: 'Network module', type: 'text' },
+        { key: 'network_dim', label: 'Network dim', type: 'number' },
+        { key: 'network_alpha', label: 'Network alpha', type: 'number' },
+        { key: 'timestep_sampling', label: 'Timestep sampling', type: 'text' },
+        { key: 'discrete_flow_shift', label: 'Discrete flow shift', type: 'number' },
+        { key: 'max_train_epochs', label: 'Max train epochs', type: 'number' },
+        { key: 'save_every_n_epochs', label: 'Save every n epochs', type: 'number' },
+        { key: 'seed', label: 'Seed', type: 'number' },
+        { key: 'optimizer_args', label: 'Optimizer args', type: 'text' },
+        { key: 'max_grad_norm', label: 'Max grad norm', type: 'number' },
+        { key: 'lr_scheduler', label: 'LR scheduler', type: 'text' },
+        { key: 'lr_scheduler_power', label: 'LR scheduler power', type: 'number' },
+        { key: 'lr_scheduler_min_lr_ratio', label: 'LR min lr ratio', type: 'number' },
+        { key: 'lr_warmup_steps', label: 'LR warmup steps', type: 'number' },
+        { key: 'output_dir', label: 'Output dir', type: 'text' },
+        { key: 'output_name', label: 'Output name', type: 'text' },
+        { key: 'metadata_title', label: 'Metadata title', type: 'text' },
+        { key: 'metadata_author', label: 'Metadata author', type: 'text' },
+        { key: 'preserve_distribution_shape', label: 'Preserve distribution shape', type: 'checkbox' },
+        { key: 'min_timestep', label: 'Min timestep', type: 'number' },
+        { key: 'max_timestep', label: 'Max timestep', type: 'number' },
+        { key: 'img_in_txt_in_offloading', label: 'img_in_txt_in_offloading', type: 'checkbox' },
+        { key: 'log_with', label: 'Log with', type: 'text' },
+        { key: 'logging_dir', label: 'Logging dir', type: 'text' },
+        { key: 'offload_inactive_dit', label: 'Offload inactive DiT', type: 'checkbox' },
+        { key: 'persistent_data_loader_workers', label: 'Persistent data loader workers', type: 'checkbox' },
+        { key: 'timestep_boundary', label: 'Timestep boundary', type: 'number' },
+        { key: 'vae_cache_cpu', label: 'VAE cache CPU', type: 'checkbox' },
+        { key: 'vae_dtype', label: 'VAE dtype', type: 'text' },
+        { key: 'sdpa', label: 'SDPA attention', type: 'checkbox' },
+        { key: 'blocks_to_swap', label: 'Blocks to swap', type: 'number' },
+        { key: 'network_args', label: 'Network args (one per line)', type: 'textarea' },
+    ];
+
+      function buildDefaultParams(trainingMode = 't2v') {
+        const isT2V = trainingMode === 't2v';
+        const shared = {
+          task: isT2V ? 't2v-A14B' : 'i2v-A14B',
+          vae: DEFAULT_PATHS.vae,
+          t5: DEFAULT_PATHS.t5,
+          mixed_precision: 'fp16',
+          fp8_base: true,
+          optimizer_type: 'adamw',
+          learning_rate: 0.0003,
+          gradient_checkpointing: true,
+          gradient_accumulation_steps: 1,
+          max_data_loader_n_workers: 8,
+          network_module: 'networks.lora_wan',
+          network_dim: 16,
+          network_alpha: 16,
+          timestep_sampling: 'shift',
+          discrete_flow_shift: 1,
+          max_train_epochs: 100,
+          save_every_n_epochs: 20,
+          seed: 5,
+          optimizer_args: 'weight_decay=0.1',
+          max_grad_norm: 0,
+          lr_scheduler: 'polynomial',
+          lr_scheduler_power: 8,
+          lr_scheduler_min_lr_ratio: 0.00005,
+          output_dir: DEFAULT_PATHS.outputDir,
+          metadata_author: 'authorName',
+          preserve_distribution_shape: true,
+          sdpa: true,
+        };
+
+        const high = {
+          dit: isT2V ? DEFAULT_PATHS.t2vHigh : DEFAULT_PATHS.i2vHigh,
+          min_timestep: 875,
+          max_timestep: 1000,
+        };
+
+        const low = {
+          dit: isT2V ? DEFAULT_PATHS.t2vLow : DEFAULT_PATHS.i2vLow,
+          min_timestep: 0,
+          max_timestep: 875,
+        };
+
+        return { shared, high, low };
+      }
+
+      function renderParams(container, values = {}) {
+        if (!container) return;
+        container.innerHTML = '';
+        PARAM_DEFINITIONS.forEach((def) => {
+          const card = document.createElement('div');
+          card.className = 'param-card';
+          card.dataset.key = def.key;
+
+          const label = document.createElement('label');
+          label.textContent = def.label;
+          card.appendChild(label);
+
+          let input;
+          if (def.type === 'checkbox') {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'checkbox-row';
+            input = document.createElement('input');
+            input.type = 'checkbox';
+            wrapper.appendChild(input);
+            wrapper.appendChild(document.createTextNode(' Enable'));
+            card.appendChild(wrapper);
+          } else if (def.type === 'textarea') {
+            input = document.createElement('textarea');
+            card.appendChild(input);
+          } else {
+            input = document.createElement('input');
+            input.type = def.type || 'text';
+            if (def.type === 'number') {
+              input.step = 'any';
+            }
+            card.appendChild(input);
+          }
+
+          const value = values[def.key];
+          if (def.type === 'checkbox') {
+            input.checked = Boolean(value ?? false);
+          } else if (def.type === 'textarea') {
+            if (Array.isArray(value)) {
+              input.value = value.join('\n');
+            } else if (value !== undefined && value !== null) {
+              input.value = value.toString();
+            }
+          } else if (value !== undefined && value !== null) {
+            input.value = value;
+          }
+
+          card.appendChild(input);
+          container.appendChild(card);
+        });
+      }
+
+      function applyParams(container, values = {}) {
+        if (!container) return;
+        container.querySelectorAll('.param-card').forEach((card) => {
+          const key = card.dataset.key;
+          const input = card.querySelector('input, textarea');
+          if (!input || !(key in values)) {
+            return;
+          }
+          const value = values[key];
+          if (input.type === 'checkbox') {
+            input.checked = Boolean(value);
+          } else if (input.tagName === 'TEXTAREA') {
+            if (Array.isArray(value)) {
+              input.value = value.join('\n');
+            } else {
+              input.value = value ?? '';
+            }
+          } else if (input.type === 'number') {
+            if (value === '' || value === null || value === undefined) {
+              input.value = '';
+            } else {
+              input.value = Number(value);
+            }
+          } else {
+            input.value = value ?? '';
+          }
+        });
+      }
+
+      function collectParams(container) {
+        const params = {};
+        if (!container) return params;
+        container.querySelectorAll('.param-card').forEach((card) => {
+          const key = card.dataset.key;
+          const input = card.querySelector('input, textarea');
+          if (!input) {
+            return;
+          }
+          if (input.type === 'checkbox') {
+            if (input.checked) {
+              params[key] = true;
+            }
+            return;
+          }
+          if (input.tagName === 'TEXTAREA') {
+            const lines = input.value
+              .split('\n')
+              .map((line) => line.trim())
+              .filter((line) => line.length > 0);
+            if (lines.length) {
+              params[key] = lines;
+            }
+            return;
+          }
+          const raw = input.value.trim();
+          if (!raw) {
+            return;
+          }
+          if (input.type === 'number') {
+            const numeric = Number(raw);
+            if (Number.isFinite(numeric)) {
+              params[key] = numeric;
+            }
+          } else {
+            params[key] = raw;
+          }
+        });
+        return params;
+      }
+
+      function buildTrainingParamsPayload(splitCommands) {
+        const shared = collectParams(sharedParamsContainer);
+        const high = splitCommands ? collectParams(highParamsContainer) : {};
+        const low = splitCommands ? collectParams(lowParamsContainer) : {};
+        return {
+          split_commands: Boolean(splitCommands),
+          shared,
+          high,
+          low,
+        };
+      }
+
+      function setSplitParamsUI(enabled) {
+        if (!perNoiseParams) return;
+        perNoiseParams.classList.toggle('hidden', !enabled);
+      }
 
       function setDatasetMessage(text = '', isError = false) {
         if (!datasetMessage) {
@@ -1230,6 +1595,154 @@
         }
       }
 
+      function setPresetMessage(text, isError = false) {
+        if (!presetMessage) return;
+        presetMessage.textContent = text;
+        presetMessage.style.color = isError ? '#ff8a80' : 'var(--muted)';
+      }
+
+      function applyPresetData(data) {
+        if (!data) return;
+        const mode = (data.training_mode || 't2v').toLowerCase();
+        const defaults = buildDefaultParams(mode);
+        const trainParams = data.train_params || {};
+        const sharedParams = { ...defaults.shared, ...(trainParams.shared || {}) };
+        const highParams = { ...defaults.high, ...(trainParams.high || {}) };
+        const lowParams = { ...defaults.low, ...(trainParams.low || {}) };
+
+        renderParams(sharedParamsContainer, sharedParams);
+        renderParams(highParamsContainer, highParams);
+        renderParams(lowParamsContainer, lowParams);
+
+        const splitCommands = Boolean(trainParams.split_commands);
+        if (splitParamsToggle) {
+          splitParamsToggle.checked = splitCommands;
+        }
+        setSplitParamsUI(splitCommands);
+
+        const datasetInput = form.querySelector('input[name="datasetPath"]');
+        if (datasetInput && data.dataset_path) {
+          datasetInput.value = data.dataset_path;
+        }
+
+        const titleInput = form.querySelector('input[name="titleSuffix"]');
+        if (titleInput && data.title_suffix) {
+          titleInput.value = data.title_suffix;
+        }
+
+        const authorInput = form.querySelector('input[name="author"]');
+        if (authorInput && data.author) {
+          authorInput.value = data.author;
+        }
+
+        const convertCheckbox = form.querySelector('input[name="convertVideos"]');
+        if (convertCheckbox) {
+          convertCheckbox.checked = Boolean(data.convert_videos_to_16fps);
+        }
+
+        const modeInput = form.querySelector(`input[name="trainingMode"][value="${mode}"]`);
+        if (modeInput) {
+          modeInput.checked = true;
+        }
+
+        const noiseMode = (data.noise_mode || 'both').toLowerCase();
+        const noiseInput = form.querySelector(`input[name="noiseMode"][value="${noiseMode}"]`);
+        if (noiseInput) {
+          noiseInput.checked = true;
+        }
+      }
+
+      async function refreshPresetOptions() {
+        if (!presetSelect) return;
+        presetSelect.innerHTML = '';
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Select a preset';
+        presetSelect.appendChild(placeholder);
+        try {
+          const response = await fetch('/presets');
+          if (!response.ok) {
+            throw new Error('Failed to load presets');
+          }
+          const data = await response.json();
+          (data.presets || []).forEach((name) => {
+            const option = document.createElement('option');
+            option.value = name;
+            option.textContent = name;
+            presetSelect.appendChild(option);
+          });
+        } catch (error) {
+          setPresetMessage(error?.message || 'Failed to load presets.', true);
+        }
+      }
+
+      async function loadPresetByName(name) {
+        const normalized = (name || '').toString().trim();
+        if (!normalized) {
+          setPresetMessage('Pick a preset to load.');
+          return;
+        }
+        setPresetMessage('Loading preset…');
+        const safeName = normalized.replace(/^\//, '');
+        try {
+          const response = await fetch(`/presets/${encodeURIComponent(safeName)}`);
+          const data = await response.json().catch(() => ({}));
+          if (!response.ok) {
+            throw new Error(data?.detail || 'Failed to load preset');
+          }
+          applyPresetData(data);
+          setPresetMessage(`Loaded preset ${normalized}.`);
+        } catch (error) {
+          setPresetMessage(error?.message || 'Failed to load preset.', true);
+        }
+      }
+
+      async function saveCurrentPreset() {
+        const name = (presetNameInput?.value || '').trim();
+        if (!name) {
+          setPresetMessage('Enter a preset name, e.g. /u/AI_Characters.', true);
+          return;
+        }
+
+        const datasetPath = (form.querySelector('input[name="datasetPath"]')?.value || '').trim();
+        if (!datasetPath) {
+          setPresetMessage('Dataset path is required to save a preset.', true);
+          return;
+        }
+
+        const trainingMode = (form.querySelector('input[name="trainingMode"]:checked')?.value || 't2v').toLowerCase();
+        const noiseMode = (form.querySelector('input[name="noiseMode"]:checked')?.value || 'both').toLowerCase();
+        const convertVideos = form.querySelector('input[name="convertVideos"]')?.checked || false;
+        const splitCommands = splitParamsToggle?.checked || false;
+        const presetPayload = {
+          name,
+          dataset_path: datasetPath,
+          training_mode: trainingMode,
+          noise_mode: noiseMode,
+          convert_videos_to_16fps: convertVideos,
+          train_params: buildTrainingParamsPayload(splitCommands),
+          title_suffix: form.querySelector('input[name="titleSuffix"]')?.value || undefined,
+          author: form.querySelector('input[name="author"]')?.value || undefined,
+        };
+
+        setPresetMessage('Saving preset…');
+        try {
+          const response = await fetch('/presets/save', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(presetPayload),
+          });
+          const data = await response.json().catch(() => ({}));
+          if (!response.ok) {
+            throw new Error(data?.detail || 'Failed to save preset');
+          }
+          setPresetMessage('Preset saved.');
+          await refreshPresetOptions();
+        } catch (error) {
+          setPresetMessage(error?.message || 'Failed to save preset.', true);
+        }
+      }
+
       async function refreshCloudStatus() {
         try {
           const response = await fetch('/cloud-status');
@@ -1596,6 +2109,44 @@
         }
       });
 
+      function initializeParamsUI() {
+        const trainingMode = (form.querySelector('input[name="trainingMode"]:checked')?.value || 't2v').toLowerCase();
+        const defaults = buildDefaultParams(trainingMode);
+        renderParams(sharedParamsContainer, defaults.shared);
+        renderParams(highParamsContainer, defaults.high);
+        renderParams(lowParamsContainer, defaults.low);
+        setSplitParamsUI(splitParamsToggle?.checked || false);
+      }
+
+      initializeParamsUI();
+      refreshPresetOptions();
+
+      if (splitParamsToggle) {
+        splitParamsToggle.addEventListener('change', () => setSplitParamsUI(splitParamsToggle.checked));
+      }
+
+      form.querySelectorAll('input[name="trainingMode"]').forEach((input) => {
+        input.addEventListener('change', () => {
+          initializeParamsUI();
+        });
+      });
+
+      if (loadPresetButton) {
+        loadPresetButton.addEventListener('click', () => loadPresetByName(presetSelect?.value || presetNameInput?.value || ''));
+      }
+
+      if (presetSelect) {
+        presetSelect.addEventListener('change', (event) => {
+          if (presetNameInput && event.target.value) {
+            presetNameInput.value = event.target.value;
+          }
+        });
+      }
+
+      if (savePresetButton) {
+        savePresetButton.addEventListener('click', saveCurrentPreset);
+      }
+
       function setStatus(text) {
         statusEl.textContent = text;
       }
@@ -1688,6 +2239,8 @@
         const noiseModeRaw = (formData.get('noiseMode') || 'both').toString().toLowerCase();
         const noiseMode = noiseModeRaw === 'high' || noiseModeRaw === 'low' ? noiseModeRaw : 'both';
         const selectedRuns = noiseMode === 'high' ? ['high'] : noiseMode === 'low' ? ['low'] : ['high', 'low'];
+        const splitCommands = splitParamsToggle?.checked || false;
+        const trainParams = buildTrainingParamsPayload(splitCommands);
         const payload = {
           title_suffix: (formData.get('titleSuffix') || '').toString().trim() || 'mylora',
           author: (formData.get('author') || '').toString().trim() || 'authorName',
@@ -1701,7 +2254,10 @@
           auto_confirm: true,
           training_mode: trainingMode,
           noise_mode: noiseMode,
+          train_params: trainParams,
         };
+
+        trainParams.shared.save_every_n_epochs = payload.save_every;
 
         if (currentCloudStatus && !currentCloudStatus.can_upload) {
           payload.upload_cloud = false;


### PR DESCRIPTION
## Summary
- add preset save/load endpoints plus bundled presets for AI_Characters and ding-a-ling-berries (turbo)
- expand the web UI with full hyperparameter controls, shared/per-noise overrides, and preset workflows
- update the training runner to consume custom parameter JSON for high/low runs

## Testing
- python -m py_compile webui/server.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f8ec07d508333abcbb8c78c49182e)