### PR TITLE
Fix bulk caption textarea overflow

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -216,6 +216,7 @@
 
       .quick-caption textarea {
         width: 100%;
+        max-width: 100%;
         min-height: 60px;
         padding: 0.55rem 0.65rem;
         border-radius: 10px;
@@ -225,6 +226,7 @@
         font-family: inherit;
         font-size: 0.9rem;
         resize: vertical;
+        box-sizing: border-box;
       }
 
       .quick-caption-hint {


### PR DESCRIPTION
## Summary
- prevent the quick caption textarea from overflowing its container by constraining width and box sizing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923bafd1ccc8333a0ef63bdc2db8792)