### PR TITLE
Align data loader workers with CPU threads

### DIFF
--- a/run_wan_training.sh
+++ b/run_wan_training.sh
@@ -506,7 +506,7 @@ calculate_cpu_params() {
 
   if [[ -n "$threads" && "$threads" =~ ^[0-9]+$ && "$threads" -gt 0 ]]; then
     cpu_threads_per_process=$((threads / 4))
-    max_data_loader_workers=$((threads / 8))
+    max_data_loader_workers=$cpu_threads_per_process
 
     if [[ "$cpu_threads_per_process" -lt 1 ]]; then
       cpu_threads_per_process=1

--- a/webui/index.html
+++ b/webui/index.html
@@ -756,16 +756,6 @@
             </label>
           </div>
           <div class="form-row two-col">
-            <label>
-              CPU threads per process (leave blank for auto)
-              <input type="number" name="cpuThreads" min="1" placeholder="Auto" />
-            </label>
-            <label>
-              Max data loader workers (leave blank for auto)
-              <input type="number" name="maxWorkers" min="1" placeholder="Auto" />
-            </label>
-          </div>
-          <div class="form-row two-col">
             <label class="toggle">
               <input type="checkbox" name="uploadCloud" checked />
               Upload LoRAs to cloud storage after training
@@ -2115,8 +2105,6 @@
           dataset_path: (formData.get('datasetPath') || '').toString().trim(),
           save_every: Number(formData.get('saveEvery')) || 100,
           max_epochs: Number(formData.get('maxEpochs')) || 100,
-          cpu_threads_per_process: formData.get('cpuThreads') ? Number(formData.get('cpuThreads')) : null,
-          max_data_loader_workers: formData.get('maxWorkers') ? Number(formData.get('maxWorkers')) : null,
           upload_cloud: formData.get('uploadCloud') === 'on',
           shutdown_instance: formData.get('shutdownInstance') === 'on',
           convert_videos_to_16fps: formData.get('convertVideos') === 'on',


### PR DESCRIPTION
## Summary
- remove CPU thread and data loader worker inputs from the web UI form
- stop sending CPU thread and data loader worker values from the client payload
- set the training script’s max data loader workers to match CPU threads instead of halving them

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926446d4e0c8333a7b0e8746eec342f)