### PR TITLE
Prevent trailing hyphen in title prefix sanitization

### DIFF
--- a/run_wan_training.sh
+++ b/run_wan_training.sh
@@ -552,7 +552,8 @@ main() {
     echo "Title prefix (auto): $TITLE_PREFIX"
   fi
   TITLE_PREFIX=${TITLE_PREFIX:-mylora}
-  TITLE_PREFIX="$(echo "$TITLE_PREFIX" | tr '[:space:]' '-')"
+  # Trim surrounding whitespace before replacing interior whitespace with dashes to avoid trailing hyphens
+  TITLE_PREFIX="$(echo "$TITLE_PREFIX" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/[[:space:]]\+/-/g')"
 
   if [[ -z "${AUTHOR_INPUT:-}" ]]; then
     if (( AUTO_CONFIRM )); then


### PR DESCRIPTION
## Summary
- trim whitespace from provided title prefix before replacing interior spaces with dashes to avoid adding trailing hyphens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940811f12d0833383c559db23ccb829)