### PR TITLE
Support Vast.ai `--raw` connections output and add cloud connection selection

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -971,6 +971,14 @@
             </label>
           </div>
           <div id="cloudStatusMessage" class="status-note" aria-live="polite"></div>
+          <div class="form-row" id="cloudConnectionRow">
+            <label>
+              Cloud upload destination
+              <select id="cloudConnectionSelect" name="cloudConnection">
+                <option value="">Default cloud connection</option>
+              </select>
+            </label>
+          </div>
           <div class="form-row" id="vastApiSection">
             <label>
               Vast.ai API key for cloud uploads
@@ -1077,6 +1085,8 @@
       const shutdownCheckbox = form.querySelector('input[name="shutdownInstance"]');
       const shutdownLabel = shutdownCheckbox ? shutdownCheckbox.closest('.toggle') : null;
       const cloudStatusMessageEl = document.getElementById('cloudStatusMessage');
+      const cloudConnectionRow = document.getElementById('cloudConnectionRow');
+      const cloudConnectionSelect = document.getElementById('cloudConnectionSelect');
       const vastApiSection = document.getElementById('vastApiSection');
       const apiKeyInput = document.getElementById('vastApiKeyInput');
       const apiKeyButton = document.getElementById('saveApiKeyButton');
@@ -2006,6 +2016,7 @@
       function setCloudStatusUI(status) {
         currentCloudStatus = status || null;
         const isVastInstance = status?.is_vast_instance !== false;
+        const connections = Array.isArray(status?.connections) ? status.connections : [];
         if (cloudStatusMessageEl) {
           const message =
             status?.message ||
@@ -2020,6 +2031,36 @@
           } else {
             cloudStatusMessageEl.style.color = 'var(--muted)';
           }
+        }
+
+        if (cloudConnectionSelect) {
+          const currentValue = cloudConnectionSelect.value;
+          cloudConnectionSelect.innerHTML = '';
+          const defaultOption = document.createElement('option');
+          defaultOption.value = '';
+          defaultOption.textContent = 'Default cloud connection';
+          cloudConnectionSelect.appendChild(defaultOption);
+          connections.forEach((connection) => {
+            const option = document.createElement('option');
+            option.value = connection.id || '';
+            const labelParts = [connection.name || connection.id || 'Cloud connection'];
+            if (connection.cloud_type) {
+              labelParts.push(`(${connection.cloud_type})`);
+            }
+            option.textContent = labelParts.join(' ');
+            cloudConnectionSelect.appendChild(option);
+          });
+          if (connections.length === 1 && !currentValue) {
+            cloudConnectionSelect.value = connections[0].id || '';
+          } else if (currentValue) {
+            cloudConnectionSelect.value = currentValue;
+          }
+          cloudConnectionSelect.disabled = !status?.can_upload;
+        }
+
+        if (cloudConnectionRow) {
+          const showConnections = isVastInstance && connections.length > 1;
+          cloudConnectionRow.classList.toggle('is-hidden', !showConnections);
         }
 
         if (uploadCloudCheckbox) {
@@ -2620,6 +2661,7 @@
           auto_confirm: true,
           training_mode: trainingMode,
           noise_mode: noiseMode,
+          cloud_connection_id: (formData.get('cloudConnection') || '').toString().trim() || null,
         };
 
         if (currentCloudStatus && !currentCloudStatus.can_upload) {


### PR DESCRIPTION
### Motivation
- Vast.ai changed the `vastai show connections` output; the UI/backend must parse the new `--raw` JSON output to reliably detect cloud integrations. 
- When multiple cloud endpoints exist, users need a way to pick the desired destination for uploads instead of always using the first connection.
- Validate and carry the chosen connection ID end-to-end so uploads use the selected endpoint and fall back cleanly if the selection is invalid.

### Description
- Update `parse_cloud_connections` to detect and parse JSON (or fall back to legacy text) returned by `vastai show connections --raw` and return normalized connection objects. 
- Switch the CLI call to include `--raw` in both `webui/server.py` (`gather_cloud_status`) and `run_wan_training.sh` (all connection checks). 
- Add an optional `cloud_connection_id` field to the training API (`TrainRequest`) and include it in the command line (`--cloud-connection-id`) passed to `run_wan_training.sh`. 
- Add a cloud connection selector to the Web UI (`webui/index.html`) that populates from `/cloud-status` and sends the selected connection ID with the `/train` request. 
- Enhance `run_wan_training.sh` to parse `--raw` output (via a small embedded Python snippet), support `--cloud-connection-id` and `WAN_CLOUD_CONNECTION_ID`, prompt/select a connection when multiple are present, and pass the preferred connection to the upload step; also validate CLI/env-selected IDs against discovered connections and fall back when missing. 
- Server-side: validate provided `cloud_connection_id` against discovered connections and log/fallback to default if it's not found.

### Testing
- Served the web UI locally and captured a screenshot of the updated form to verify the new cloud connection dropdown is rendered and populated (succeeded). 
- Performed static inspections (`rg`/`sed`/searches) to confirm call sites and flags were updated to use `--raw` and that the new payload/CLI option is threaded end-to-end (succeeded). 
- No automated unit/integration test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69814cfe91d0833385c3bda3f52e79ad)